### PR TITLE
boostrapper -> bootstrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Fully destroy this DHT node.
 This will also unannounce any running servers.
 If you want to force close the node without waiting for the servers to unannounce pass `{ force: true }`.
 
-#### `node = DHT.boostrapper(bind, [options])`
+#### `node = DHT.bootstrapper(bind, [options])`
 
 If you want to run your own Hyperswarm network use this method to easily create a bootstrap node.
 


### PR DESCRIPTION
bootstrapper was spelt as boostrapper
```diff
- DHT.boostrapper(bind,[options])
+ DHT.bootstrapper(bind,[options])
```