### PR TITLE
noise wrap passes optional curve to noise handshake async recv

### DIFF
--- a/lib/noise-wrap.js
+++ b/lib/noise-wrap.js
@@ -10,11 +10,11 @@ const { NS } = require('./constants')
 const NOISE_PROLOUGE = NS.PEER_HANDSHAKE
 
 module.exports = class NoiseWrap {
-  constructor (keyPair, remotePublicKey) {
+  constructor (keyPair, remotePublicKey, opts = {}) {
     this.isInitiator = !!remotePublicKey
     this.remotePublicKey = remotePublicKey
     this.keyPair = keyPair
-    this.handshake = new NoiseHandshake('IK', this.isInitiator, keyPair, { curve })
+    this.handshake = new NoiseHandshake('IK', this.isInitiator, keyPair, { curve: opts.curve || curve })
     this.handshake.initialise(NOISE_PROLOUGE, remotePublicKey)
   }
 
@@ -23,8 +23,8 @@ module.exports = class NoiseWrap {
     return this.handshake.send(buf)
   }
 
-  recv (buf) {
-    const payload = c.decode(m.noisePayload, this.handshake.recv(buf))
+  async recv (buf) {
+    const payload = c.decode(m.noisePayload, await this.handshake.recv(buf))
     this.remotePublicKey = b4a.toBuffer(this.handshake.rs)
     return payload
   }


### PR DESCRIPTION
The noise handshake used in peers connection could use a custom Diffie-Hellman implementation. The Noisewarp constructor would benefit from passing the curve to the NoiseHandshake constructor making it more flexible. Besides, the implementation could be asynchronous so the receive method must await in order to decode the received buffer.

See this example:

``` js
const createHandshake = (keyPair, remotePublicKey) => {
	const curve = {
          dh: async (pk, seck) => customDH(pk, seck),
	  PKLEN: 32,
          ALG: 'Ed25519',
          name: 'Ed25519',
	  generateKeyPair
	}
	return new NoiseWrap(keyPair, remotePublicKey, { curve })
}

const node = new DHT()
const server = node.createServer({ createHandshake })
```