### PR TITLE
Breaking Feature: add opaque userData message to peer records

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,11 @@ The returned stream looks like this
   // What address they responded to (i.e. your address)
   to: { host, port },
   // List of peers announcing under this topic
-  peers: [ { publicKey, nodes: [{ host, port }, ...] } ]
+  peers: [ { 
+    publicKey, 
+    relayAddresses: [{ host, port }, ...], 
+    userData: <Buffer ...> 
+  } ]
 }
 ```
 
@@ -223,6 +227,8 @@ An announce does a parallel lookup so the stream returned looks like the lookup 
 Creating a server using `dht.createServer` automatically announces itself periodically on the key-pair it is listening on. When announcing the server under a specific topic, you can access the nodes it is close to using `server.nodes`.
 
 If you pass any options they are forwarded to dht-rpc.
+
+You can pass small application specific opaque token as `options.userData`, as long as the entire record fits in MTU, keeping the token smaller than 600 bytes should work.
 
 #### `await node.unannounce(topic, keyPair, [options])`
 

--- a/index.js
+++ b/index.js
@@ -150,7 +150,8 @@ class HyperDHT extends DHT {
         reply.token,
         reply.from,
         relayAddresses,
-        signAnnounce
+        signAnnounce,
+        opts.userData
       )
     }
   }
@@ -337,11 +338,12 @@ class HyperDHT extends DHT {
     return this._rawStreams.add(opts)
   }
 
-  async _requestAnnounce (keyPair, dht, target, token, from, relayAddresses, sign) {
+  async _requestAnnounce (keyPair, dht, target, token, from, relayAddresses, sign, userData) {
     const ann = {
       peer: {
         publicKey: keyPair.publicKey,
-        relayAddresses: relayAddresses || []
+        relayAddresses: relayAddresses || [],
+        userData
       },
       refresh: null,
       signature: null

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -263,15 +263,18 @@ const peer = exports.peer = {
   preencode (state, m) {
     state.end += 32
     ipv4Array.preencode(state, m.relayAddresses)
+    c.buffer.preencode(state, m.userData)
   },
   encode (state, m) {
     c.fixed32.encode(state, m.publicKey)
     ipv4Array.encode(state, m.relayAddresses)
+    c.buffer.encode(state, m.userData)
   },
-  decode (state) {
+  decode (state, userData = true) {
     return {
       publicKey: c.fixed32.decode(state),
-      relayAddresses: ipv4Array.decode(state)
+      relayAddresses: ipv4Array.decode(state),
+      userData: userData ? c.buffer.decode(state) : null
     }
   }
 }
@@ -286,7 +289,8 @@ exports.announce = {
     if (m.signature) state.end += 64
   },
   encode (state, m) {
-    const flags = (m.peer ? 1 : 0) | (m.refresh ? 2 : 0) | (m.signature ? 4 : 0)
+    let flags = (m.peer ? 1 : 0) | (m.refresh ? 2 : 0) | (m.signature ? 4 : 0)
+    flags |= 8 // new peer encoding with userData
     c.uint.encode(state, flags)
     if (m.peer) peer.encode(state, m.peer)
     if (m.refresh) c.fixed32.encode(state, m.refresh)
@@ -296,7 +300,7 @@ exports.announce = {
     const flags = c.uint.decode(state)
 
     return {
-      peer: (flags & 1) !== 0 ? peer.decode(state) : null,
+      peer: (flags & 1) !== 0 ? peer.decode(state, (flags & 8) !== 0) : null,
       refresh: (flags & 2) !== 0 ? c.fixed32.decode(state) : null,
       signature: (flags & 4) !== 0 ? c.fixed64.decode(state) : null
     }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -270,11 +270,11 @@ const peer = exports.peer = {
     ipv4Array.encode(state, m.relayAddresses)
     c.buffer.encode(state, m.userData)
   },
-  decode (state, userData = true) {
+  decode (state) {
     return {
       publicKey: c.fixed32.decode(state),
       relayAddresses: ipv4Array.decode(state),
-      userData: userData ? c.buffer.decode(state) : null
+      userData: c.buffer.decode(state)
     }
   }
 }
@@ -289,8 +289,7 @@ exports.announce = {
     if (m.signature) state.end += 64
   },
   encode (state, m) {
-    let flags = (m.peer ? 1 : 0) | (m.refresh ? 2 : 0) | (m.signature ? 4 : 0)
-    flags |= 8 // new peer encoding with userData
+    const flags = (m.peer ? 1 : 0) | (m.refresh ? 2 : 0) | (m.signature ? 4 : 0)
     c.uint.encode(state, flags)
     if (m.peer) peer.encode(state, m.peer)
     if (m.refresh) c.fixed32.encode(state, m.refresh)
@@ -300,7 +299,7 @@ exports.announce = {
     const flags = c.uint.decode(state)
 
     return {
-      peer: (flags & 1) !== 0 ? peer.decode(state, (flags & 8) !== 0) : null,
+      peer: (flags & 1) !== 0 ? peer.decode(state) : null,
       refresh: (flags & 2) !== 0 ? c.fixed32.decode(state) : null,
       signature: (flags & 4) !== 0 ? c.fixed64.decode(state) : null
     }

--- a/test/announces.js
+++ b/test/announces.js
@@ -84,3 +84,18 @@ test('server listen returns server', async function (t) {
   t.ok(result.length > 0, 'has at least one result')
   t.alike(result[0].peer.publicKey, server.publicKey)
 })
+
+test('announce with userData', async function (t) {
+  const [a, b] = await swarm(t)
+  const keyPair = DHT.keyPair()
+  const target = DHT.hash(Buffer.from('testing...'))
+
+  const userData = Buffer.alloc(600).fill('user-data')
+
+  await a.announce(target, keyPair, [], { userData }).finished()
+
+  const result = await toArray(b.lookup(target))
+  const peer = result[0].peers[0]
+
+  t.alike(peer.userData, userData)
+})

--- a/test/messages.js
+++ b/test/messages.js
@@ -293,7 +293,7 @@ test('peers', function (t) {
   }, {
     publicKey: Buffer.alloc(32).fill('another'),
     relayAddresses: [],
-    userData: null
+    userData: Buffer.alloc(500).fill('user-data')
   }]
 
   m.peers.preencode(state, peers)


### PR DESCRIPTION
closes #127 

TLDR: adding `userData` to peer encoding will enable similar use cases to `mutablePut` but with two main differences:
1 - Peers can advertise capability tokens/attestations they hold vs an ACL like in [Seeders swarm](https://github.com/holepunchto/hyperswarm-seeders)
2 - Advertised data in `peer.userData` can use any application-specific schemas or be signed by any crypto without coupling Hyperswarm with such details.