### PR TITLE
Allow configuring hole puncher probe counts

### DIFF
--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -1,5 +1,5 @@
 const b4a = require('b4a')
-const Semaphore = require('semaphore')
+const Semaphore = require('./semaphore')
 const Nat = require('./nat')
 const Sleeper = require('./sleeper')
 const { FIREWALL } = require('./constants')

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -223,9 +223,10 @@ module.exports = class Holepuncher {
     let tries = 0
 
     while (this.punching && await this._consistentProbeSem.wait()) {
+      tries++
       for (const addr of this.remoteAddresses) {
         // only try unverified addresses every 4 ticks
-        if (!addr.verified && ((++tries & 3) !== 0)) continue
+        if (!addr.verified && ((tries & 3) !== 0)) continue
         await holepunch(this._holder.socket, addr, false)
       }
       if (this.punching) await this._sleeper.pause(1000)

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -1,4 +1,5 @@
 const b4a = require('b4a')
+const Semaphore = require('semaphore')
 const Nat = require('./nat')
 const Sleeper = require('./sleeper')
 const { FIREWALL } = require('./constants')
@@ -10,8 +11,13 @@ const DEFAULT_TTL = 64
 const MAX_REOPENS = 3
 
 module.exports = class Holepuncher {
-  constructor (dht, session, isInitiator, remoteFirewall = FIREWALL.UNKNOWN) {
+  constructor (dht, session, isInitiator, remoteFirewall = FIREWALL.UNKNOWN, opts = {}) {
     const holder = dht._socketPool.acquire()
+
+    const {
+      consistentProbeCount = 10,
+      randomProbeCount = 1750 // ~35 seconds
+    } = opts
 
     this.dht = dht
     this.session = session
@@ -33,6 +39,9 @@ module.exports = class Holepuncher {
     this.remoteFirewall = remoteFirewall
     this.remoteAddresses = []
     this.remoteHolepunching = false
+
+    this._consistentProbeSem = new Semaphore(consistentProbeCount)
+    this._randomProbeSem = new Semaphore(randomProbeCount)
 
     this._sleeper = new Sleeper()
     this._reopening = null
@@ -79,6 +88,12 @@ module.exports = class Holepuncher {
 
   openSession (addr, socket = this._holder.socket) {
     return holepunch(socket, addr, true)
+  }
+
+  probe () {
+    if (!this.punching) return
+    const remote = coerceFirewall(this.remoteFirewall)
+    return remote >= FIREWALL.RANDOM ? this._randomProbeSem.signal() : this._consistentProbeSem.signal()
   }
 
   async analyze (allowReopen) {
@@ -207,10 +222,10 @@ module.exports = class Holepuncher {
 
     let tries = 0
 
-    while (this.punching && tries++ < 10) {
+    while (this.punching && await this._consistentProbeSem.wait()) {
       for (const addr of this.remoteAddresses) {
         // only try unverified addresses every 4 ticks
-        if (!addr.verified && ((tries & 3) !== 0)) continue
+        if (!addr.verified && ((++tries & 3) !== 0)) continue
         await holepunch(this._holder.socket, addr, false)
       }
       if (this.punching) await this._sleeper.pause(1000)
@@ -221,9 +236,7 @@ module.exports = class Holepuncher {
 
   // Note that this never throws so it is safe to run in the background
   async _randomProbes (remoteAddr) {
-    let tries = 1750 // ~35s
-
-    while (this.punching && tries-- > 0) {
+    while (this.punching && await this._randomProbeSem.wait()) {
       const addr = { host: remoteAddr.host, port: randomPort() }
       await holepunch(this._holder.socket, addr, false)
       if (this.punching) await this._sleeper.pause(20)
@@ -276,6 +289,9 @@ module.exports = class Holepuncher {
     for (const ref of this._allHolders) ref.release()
     this._allHolders = []
     this.nat.destroy()
+
+    this._consistentProbeSem.destroy()
+    this._randomProbeSem.destroy()
 
     if (!this.connected) this.onabort()
   }


### PR DESCRIPTION
When the probes have been exhausted, additional probes can be sent manually with the `puncher.probe()` method. 