### PR TITLE
Add error handlers which explicitly fail to sockets

### DIFF
--- a/test/connections.js
+++ b/test/connections.js
@@ -17,11 +17,19 @@ test('createServer + connect - once defaults', async function (t) {
       lc.pass('server side ended')
       socket.end()
     })
+    socket.on('error', e => {
+      console.error(e)
+      t.fail('unexpected socket error')
+    })
   })
 
   await server.listen()
 
   const socket = b.connect(server.publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   socket.once('open', function () {
     lc.pass('client side opened')
@@ -62,6 +70,10 @@ test('createServer + connect - emits connect', async function (t) {
   await server.listen()
 
   const socket = b.connect(server.publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   socket.once('connect', function () {
     lc.pass('client side emitted connect')
@@ -104,6 +116,11 @@ test('createServer + connect - exchange data', { timeout: 60000 }, async functio
   await server.listen()
 
   const socket = b.connect(server.publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
+
   const blk = Buffer.alloc(4096)
   const expected = 20 * 1024 * blk.byteLength
 
@@ -161,6 +178,10 @@ test('createServer + connect - force holepunch', async function (t) {
   await server.listen()
 
   const socket = b.connect(server.publicKey, { localConnection: false })
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   socket.once('open', function () {
     lc.pass('udx client side opened')
@@ -271,6 +292,11 @@ test('udp noise, client ends, no crash', async function (t) {
   const [, node] = await swarm(t, 2)
 
   const socket = node.udx.createSocket()
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
+
   await socket.send(Buffer.from('hi'), node.address().port)
   await socket.close()
 
@@ -286,6 +312,10 @@ test('half open', async function (t) {
   await server.listen()
 
   const socket = b.connect(server.address().publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   server.on('connection', (socket) => {
     socket.on('data', (data) => {
@@ -318,6 +348,11 @@ test('server responds and immediately ends, multiple connects', async function (
 
   for (let i = n; i > 0; i--) {
     const socket = b.connect(server.publicKey)
+
+    socket.on('error', e => {
+      console.error(e)
+      t.fail('unexpected socket error')
+    })
 
     socket
       .on('close', () => {
@@ -354,6 +389,11 @@ test('dht node can host server', async function (t) {
 
   const socket = c.connect(server.publicKey)
 
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
+
   socket.once('open', function () {
     lc.pass('client side opened')
   })
@@ -382,6 +422,10 @@ test('server and client on same node', async function (t) {
   await server.listen()
 
   const socket = a.connect(server.address().publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   server.on('connection', (socket) => {
     t.pass('server connected')
@@ -433,6 +477,11 @@ test('relayed connection on same node', async function (t) {
 
   const socket = a.connect(server.address().publicKey)
 
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
+
   server.on('connection', (socket) => {
     t.pass('server connected')
     socket.end()
@@ -462,6 +511,10 @@ test('create raw stream from encrypted stream', async function (t) {
   await server.listen()
 
   const socket = b.connect(server.address().publicKey)
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   const aRawStream = a.createRawStream()
   const bRawStream = b.createRawStream()
@@ -516,6 +569,11 @@ test('create many connections with reusable sockets', async function (t) {
   for (let i = 0; i < 100; i++) {
     const socket = b.connect(server.address().publicKey, { reusableSocket: true, localConnection: false })
 
+    socket.on('error', e => {
+      console.error(e)
+      t.fail('unexpected socket error')
+    })
+
     socket.on('connect', function () {
       if (prev === socket.rawStream.socket) same++
       prev = socket.rawStream.socket
@@ -530,6 +588,11 @@ test('create many connections with reusable sockets', async function (t) {
 
   for (let i = 0; i < 100; i++) {
     const socket = b.connect(server.address().publicKey, { reusableSocket: false, localConnection: false })
+
+    socket.on('error', e => {
+      console.error(e)
+      t.fail('unexpected socket error')
+    })
 
     socket.on('connect', function () {
       if (prev === socket.rawStream.socket) same++
@@ -570,6 +633,10 @@ test('connect using specific key', async function (t) {
   await server.listen()
 
   const socket = b.connect(server.publicKey, { keyPair })
+  socket.on('error', e => {
+    console.error(e)
+    t.fail('unexpected socket error')
+  })
 
   socket
     .once('open', function () {


### PR DESCRIPTION
This adds error handlers to all sockets in test/connection which before didn't have one, and make the test explicitly fail if it triggers.

I did this while debugging a (now-solved) issue with flaky tests where it was hard to figure out which test actually caused the failure.

Feel free to close if not useful