### PR TITLE
Trigger canary when releasing new version

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -5,21 +5,36 @@ on:
   push:
     branches:
       - main
+    tags: # To trigger the canary
+      - '*'
   pull_request:
     branches:
       - main
 jobs:
   build:
+    if: ${{ !startsWith(github.ref, 'refs/tags/')}} # Already runs for the push of the commit, no need to run again for the tag
     strategy:
       matrix:
         node-version: [lts/*]
         os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
-    - name: Use Node.js ${{ matrix.node-version }}
-      uses: actions/setup-node@v2
-      with:
-        node-version: ${{ matrix.node-version }}
-    - run: npm install
-    - run: npm test
+      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1 https://github.com/actions/checkout/releases/tag/v4.1.1
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@1a4442cacd436585916779262731d5b162bc6ec7 # v3.8.2 https://github.com/actions/setup-node/releases/tag/v3.8.2
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npm install
+      - run: npm test
+  trigger_canary:
+    if: startsWith(github.ref, 'refs/tags/') # Only run when a new package is published (detects when a new tag is pushed)
+    runs-on: ubuntu-latest
+    steps:
+      - name: trigger canary
+        run: |
+          curl -L -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.CANARY_DISPATCH_PAT }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/holepunchto/canary-tests/dispatches \
+          -d '{"event_type":"triggered-by-${{ github.event.repository.name }}-${{ github.ref_name }}"}'


### PR DESCRIPTION
Also fixes the commit hashes for the external actions we use, as recommended by github to protect against supply-chain attacks