### PR TITLE
Bugfix: don't create an announcer if closing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -109,6 +109,7 @@ module.exports = class Server extends EventEmitter {
     if (this.dht.destroyed) throw NODE_DESTROYED()
 
     await this.dht.bind()
+    if (this._closing) return
 
     this.target = hash(keyPair.publicKey)
 


### PR DESCRIPTION
The race condition triggered when `server.listen()` created the announcer https://github.com/holepunchto/hyperdht/blob/75059f561f633ab7f7cde214a6f7ed309f503bcb/lib/server.js#L111-L116

after `server.close()` started executing but before `await this.dht.bind()`resolved, because then `this._listening` is not yet true, and`close()` early returns if no listener is found:
https://github.com/holepunchto/hyperdht/blob/75059f561f633ab7f7cde214a6f7ed309f503bcb/lib/server.js#L83-L86



It's a catastrophic bug when it triggers, because an endless loop floods the CPU in `Announcer._background()`: https://github.com/holepunchto/hyperdht/blob/75059f561f633ab7f7cde214a6f7ed309f503bcb/lib/announcer.js#L96-L97 It will continuously throw `NODE_DESTROYED` errors which are caught and ignored
