### PR TITLE
Use catch(safetyCatch) instead of noop

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@ const DHT = require('dht-rpc')
 const sodium = require('sodium-universal')
 const c = require('compact-encoding')
 const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
 const m = require('./lib/messages')
 const SocketPool = require('./lib/socket-pool')
 const Persistent = require('./lib/persistent')
@@ -193,7 +194,7 @@ class HyperDHT extends DHT {
           data.token,
           data.from,
           signUnannounce
-        ).catch(noop)
+        ).catch(safetyCatch)
       )
 
       return data

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -3,6 +3,7 @@ const b4a = require('b4a')
 const relay = require('blind-relay')
 const DebuggingStream = require('debugging-stream')
 const { isPrivate, isBogon } = require('bogon')
+const safetyCatch = require('safety-catch')
 const Semaphore = require('./semaphore')
 const NoiseWrap = require('./noise-wrap')
 const SecurePayload = require('./secure-payload')
@@ -408,7 +409,7 @@ async function connectThroughNode (c, address, socket) {
     if (c.rawStream.connected) {
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
 
-      if (remoteChanging) remoteChanging.catch(noop)
+      if (remoteChanging) remoteChanging.catch(safetyCatch)
     } else {
       c.rawStream.connect(socket, c.connect.payload.udx.id, port, host)
 

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -1,6 +1,7 @@
 const EventEmitter = require('events')
 const b4a = require('b4a')
 const errors = require('./errors')
+const safetyCatch = require('safety-catch')
 
 module.exports = class ConnectionPool extends EventEmitter {
   constructor (dht) {
@@ -40,12 +41,12 @@ module.exports = class ConnectionPool extends EventEmitter {
         }
 
         existing
-          .on('error', noop)
+          .on('error', safetyCatch)
           .on('close', () => {
             if (closed) return
 
             stream
-              .off('error', noop)
+              .off('error', safetyCatch)
               .off('close', onclose)
 
             this._attachStream(stream, opened)
@@ -53,11 +54,11 @@ module.exports = class ConnectionPool extends EventEmitter {
           .destroy(errors.DUPLICATE_CONNECTION())
 
         stream
-          .on('error', noop)
+          .on('error', safetyCatch)
           .on('close', onclose)
       } else {
         stream
-          .on('error', noop)
+          .on('error', safetyCatch)
           .destroy(errors.DUPLICATE_CONNECTION())
       }
 
@@ -80,7 +81,7 @@ module.exports = class ConnectionPool extends EventEmitter {
       this._connecting.set(keyString, session)
 
       stream
-        .on('error', noop)
+        .on('error', safetyCatch)
         .on('close', () => {
           if (opened) this._connections.delete(keyString)
           else this._connecting.delete(keyString)
@@ -91,7 +92,7 @@ module.exports = class ConnectionPool extends EventEmitter {
           this._connecting.delete(keyString)
           this._connections.set(keyString, session)
 
-          stream.off('error', noop)
+          stream.off('error', safetyCatch)
 
           this.emit('connection', stream, session)
         })
@@ -142,5 +143,3 @@ class ConnectionRef {
     this._stream.destroy()
   }
 }
-
-function noop () {}

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -1,6 +1,5 @@
 const EventEmitter = require('events')
 const b4a = require('b4a')
-const safetyCatch = require('safety-catch')
 const errors = require('./errors')
 
 module.exports = class ConnectionPool extends EventEmitter {
@@ -41,12 +40,12 @@ module.exports = class ConnectionPool extends EventEmitter {
         }
 
         existing
-          .on('error', safetyCatch)
+          .on('error', noop)
           .on('close', () => {
             if (closed) return
 
             stream
-              .off('error', safetyCatch)
+              .off('error', noop)
               .off('close', onclose)
 
             this._attachStream(stream, opened)
@@ -54,11 +53,11 @@ module.exports = class ConnectionPool extends EventEmitter {
           .destroy(errors.DUPLICATE_CONNECTION())
 
         stream
-          .on('error', safetyCatch)
+          .on('error', noop)
           .on('close', onclose)
       } else {
         stream
-          .on('error', safetyCatch)
+          .on('error', noop)
           .destroy(errors.DUPLICATE_CONNECTION())
       }
 
@@ -81,7 +80,7 @@ module.exports = class ConnectionPool extends EventEmitter {
       this._connecting.set(keyString, session)
 
       stream
-        .on('error', safetyCatch)
+        .on('error', noop)
         .on('close', () => {
           if (opened) this._connections.delete(keyString)
           else this._connecting.delete(keyString)
@@ -92,7 +91,7 @@ module.exports = class ConnectionPool extends EventEmitter {
           this._connecting.delete(keyString)
           this._connections.set(keyString, session)
 
-          stream.off('error', safetyCatch)
+          stream.off('error', noop)
 
           this.emit('connection', stream, session)
         })
@@ -143,3 +142,5 @@ class ConnectionRef {
     this._stream.destroy()
   }
 }
+
+function noop () {}

--- a/lib/connection-pool.js
+++ b/lib/connection-pool.js
@@ -1,7 +1,7 @@
 const EventEmitter = require('events')
 const b4a = require('b4a')
-const errors = require('./errors')
 const safetyCatch = require('safety-catch')
+const errors = require('./errors')
 
 module.exports = class ConnectionPool extends EventEmitter {
   constructor (dht) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -258,7 +258,7 @@ module.exports = class Server extends EventEmitter {
         if (hs.rawStream.connected) {
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
 
-          if (remoteChanging) remoteChanging.catch(noop)
+          if (remoteChanging) remoteChanging.catch(safetyCatch)
         } else {
           hs.rawStream.connect(socket, remotePayload.udx.id, port, host)
 


### PR DESCRIPTION
Might need to be merged together with https://github.com/holepunchto/hyperswarm/pull/170, because hyperswarm at some point removes a `noop` listener created in hyperdht's `lib/connect` (although I couldn't trace which one exactly)