### PR TITLE
Bugfix: server lifecycle when closing during listen

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -117,7 +117,6 @@ module.exports = class Server extends EventEmitter {
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
-
     this._announcer = new Announcer(this.dht, keyPair, this.target, opts)
 
     this.dht._router.set(this.target, {

--- a/lib/server.js
+++ b/lib/server.js
@@ -108,12 +108,19 @@ module.exports = class Server extends EventEmitter {
     if (this._listening) throw ALREADY_LISTENING()
     if (this.dht.destroyed) throw NODE_DESTROYED()
 
+    // From now on, the DHT object which created me is responsible for closing me
+    this.dht.listening.add(this)
+
     await this.dht.bind()
     if (this._closing) return
+
+    // From now on, my close logic will be executed
+    this._listening = true
 
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
+
     this._announcer = new Announcer(this.dht, keyPair, this.target, opts)
 
     this.dht._router.set(this.target, {
@@ -122,8 +129,6 @@ module.exports = class Server extends EventEmitter {
       onpeerhandshake: this._onpeerhandshake.bind(this),
       onpeerholepunch: this._onpeerholepunch.bind(this)
     })
-
-    this._listening = true
 
     // warm it up for now
     this._localAddresses().catch(safetyCatch)
@@ -137,11 +142,12 @@ module.exports = class Server extends EventEmitter {
       throw err
     }
 
+    if (this._closing) return
     if (this.suspended) await this._announcer.suspend()
 
+    if (this._closing) return
     if (this.dht.destroyed) throw NODE_DESTROYED()
 
-    this.dht.listening.add(this)
     this.emit('listening')
 
     if (this.pool) this.pool._attachServer(this)

--- a/lib/server.js
+++ b/lib/server.js
@@ -114,9 +114,6 @@ module.exports = class Server extends EventEmitter {
     await this.dht.bind()
     if (this._closing) return
 
-    // From now on, my close logic will be executed
-    this._listening = true
-
     this.target = hash(keyPair.publicKey)
 
     this._keyPair = keyPair
@@ -129,6 +126,8 @@ module.exports = class Server extends EventEmitter {
       onpeerhandshake: this._onpeerhandshake.bind(this),
       onpeerholepunch: this._onpeerholepunch.bind(this)
     })
+
+    this._listening = true
 
     // warm it up for now
     this._localAddresses().catch(safetyCatch)

--- a/test/all.js
+++ b/test/all.js
@@ -11,6 +11,7 @@ async function runTests () {
   await import('./connections.js')
   await import('./holepuncher.js')
   await import('./keychain.js')
+  await import('./lifecycle.js')
   await import('./messages.js')
   await import('./nat.js')
   await import('./noncustodial.js')

--- a/test/lifecycle.js
+++ b/test/lifecycle.js
@@ -1,0 +1,18 @@
+const test = require('brittle')
+const { swarm } = require('./helpers')
+const safetyCatch = require('safety-catch')
+
+test('Can destroy a DHT node while server.listen() is called', async function (t) {
+  const [a] = await swarm(t)
+
+  const server = a.createServer()
+  const listenProm = server.listen()
+  listenProm.catch(safetyCatch)
+
+  await a.destroy()
+  t.ok(a.destroyed === true, 'Can destroy DHT node while listen is being called (does not hang forever)')
+  t.ok(server.closed === true, 'The server closed')
+
+  await listenProm
+  t.pass('The listen function does not error when the DHT closes while it is running')
+})


### PR DESCRIPTION
This fixes a catastrophic bug when destroying a server while listen() is being called, but before the server added itself to the DHT's server-set. This resulted in the `_background`  https://github.com/holepunchto/hyperdht/blob/55536eb95e5dfbef13bbe68f00adb1f6b1a9557a/lib/announcer.js#L96 function of the announcer entering an infinite loop hogging the event loop due to continuously throwing and catching DHT_CLOSED errors. To reproduce, you can run the newly added test on the original code.

The fix is to add the server to the DHT's server-set as soon as `listen()` is called, ensuring its `close ` function is always called when the DHT gets destroyed.

If there originally was a reason not to do immediately add a new server to the DHT's server-set, I can instead look into reworking the lifecycle a bit more in depth.
