### PR TITLE
Make server._background stop when dht destroyed

### DIFF
--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -99,7 +99,7 @@ module.exports = class Announcer {
         this._refreshing = false
 
         // ~5min +-
-        for (let i = 0; i < 100 && !this.dht.destroyed && !this.stopped && !this._refreshing && !this.suspended; i++) {
+        for (let i = 0; i < 100 && !this.stopped && !this._refreshing && !this.suspended; i++) {
           const pings = []
 
           for (const node of this._serverRelays[2].values()) {
@@ -109,14 +109,14 @@ module.exports = class Announcer {
           const active = await resolved(pings)
           if (active < MIN_ACTIVE) this.refresh() // we lost too many relay nodes, retry all
 
-          if (this.dht.destroyed || this.stopped) return
+          if (this.stopped) return
 
           if (!this.suspended && !this._refreshing) await this._sleeper.pause(3000)
         }
 
-        while (!this.dht.destroyed && !this.stopped && this.suspended) await this._resumed.wait()
+        while (!this.stopped && this.suspended) await this._resumed.wait()
 
-        if (!this.dht.destroyed && !this.stopped) await this._runUpdate()
+        if (!this.stopped) await this._runUpdate()
       } catch (err) {
         safetyCatch(err)
       }

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -94,12 +94,12 @@ module.exports = class Announcer {
   }
 
   async _background () {
-    while (!this.stopped) {
+    while (!this.dht.destroyed && !this.stopped) {
       try {
         this._refreshing = false
 
         // ~5min +-
-        for (let i = 0; i < 100 && !this.stopped && !this._refreshing && !this.suspended; i++) {
+        for (let i = 0; i < 100 && !this.dht.destroyed && !this.stopped && !this._refreshing && !this.suspended; i++) {
           const pings = []
 
           for (const node of this._serverRelays[2].values()) {
@@ -109,14 +109,14 @@ module.exports = class Announcer {
           const active = await resolved(pings)
           if (active < MIN_ACTIVE) this.refresh() // we lost too many relay nodes, retry all
 
-          if (this.stopped) return
+          if (this.dht.destroyed || this.stopped) return
 
           if (!this.suspended && !this._refreshing) await this._sleeper.pause(3000)
         }
 
-        while (!this.stopped && this.suspended) await this._resumed.wait()
+        while (!this.dht.destroyed && !this.stopped && this.suspended) await this._resumed.wait()
 
-        if (!this.stopped) await this._runUpdate()
+        if (!this.dht.destroyed && !this.stopped) await this._runUpdate()
       } catch (err) {
         safetyCatch(err)
       }


### PR DESCRIPTION
This is a more conservative approach to the infinite loop in `_background`, to also make it stop if the underlying DHT got destroyed. This protects us from bugs in the lifecycle management resulting in an infinite loop, such as https://github.com/holepunchto/hyperdht/pull/155 and https://github.com/holepunchto/hyperdht/pull/153