### PR TITLE
Ensure relay-connections-through-node test actually relays

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -34,7 +34,7 @@ module.exports = class Server extends EventEmitter {
 
     this._shareLocalAddress = opts.shareLocalAddress !== false
     this._reusableSocket = !!opts.reusableSocket
-    this._noHolepunching = opts._noHolepunching === true
+    this._neverPunch = opts.holepunch === false // useful for fully disabling punching
     this._keyPair = null
     this._announcer = null
     this._connects = new Map()
@@ -395,12 +395,10 @@ module.exports = class Server extends EventEmitter {
       }
     }
 
-    if (ourRemoteAddr) {
+    if (ourRemoteAddr || this._neverPunch) {
       hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
       return hs
     }
-
-    if (this._noHolepunching) return hs
 
     hs.payload = new SecurePayload(h.holepunchSecret)
     hs.puncher = new Holepuncher(this.dht, this.dht.session(), false, remotePayload.firewall)

--- a/lib/server.js
+++ b/lib/server.js
@@ -34,6 +34,7 @@ module.exports = class Server extends EventEmitter {
 
     this._shareLocalAddress = opts.shareLocalAddress !== false
     this._reusableSocket = !!opts.reusableSocket
+    this._noHolepunching = opts._noHolepunching === true
     this._keyPair = null
     this._announcer = null
     this._connects = new Map()
@@ -398,6 +399,8 @@ module.exports = class Server extends EventEmitter {
       hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
       return hs
     }
+
+    if (this._noHolepunching) return hs
 
     hs.payload = new SecurePayload(h.holepunchSecret)
     hs.puncher = new Holepuncher(this.dht, this.dht.session(), false, remotePayload.firewall)

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -422,9 +422,9 @@ test('relay connections through node, client and server side', async function (t
 
   await lc
 
-  await a.destroy()
-  await b.destroy()
   await c.destroy()
+  await b.destroy()
+  await a.destroy()
 })
 
 test.skip('relay several connections through node with pool', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -392,7 +392,7 @@ test('relay connections through node, client and server side', async function (t
   await aServer.listen()
 
   const bServer = b.createServer({
-    _noHolepunching: true, // To ensure it relies only on relaying
+    holepunch: false, // To ensure it relies only on relaying
     shareLocalAddress: false, // To help ensure it relies only on relaying (otherwise it can connect directly over LAN, without even trying to holepunch)
     relayThrough: aServer.publicKey
   }, function (socket) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -360,9 +360,16 @@ test('relay connections through node, client and server side', async function (t
 
   const lc = t.test('socket lifecycle')
   lc.plan(5)
+  const testRelay = t.test('relay server')
+  testRelay.plan(2) // One each for the initiator and the follower
+  const testRelayInitiator = t.test('relay initiator')
+  testRelayInitiator.plan(1)
+  const testRelayFollower = t.test('relay follower')
+  testRelayFollower.plan(1)
 
   const relay = new RelayServer({
     createStream (opts) {
+      testRelay.pass('The relay server created a relay stream')
       return a.createRawStream({ ...opts, framed: true })
     }
   })
@@ -371,6 +378,13 @@ test('relay connections through node, client and server side', async function (t
 
   const aServer = a.createServer(function (socket) {
     const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('pair', (isInitiator) => {
+      if (isInitiator) {
+        testRelayInitiator.pass('The initiator paired with the relay server')
+      } else {
+        testRelayFollower.pass('The non-iniator paired with the relay server')
+      }
+    })
     session
       .on('error', (err) => t.comment(err.message))
   })
@@ -378,6 +392,8 @@ test('relay connections through node, client and server side', async function (t
   await aServer.listen()
 
   const bServer = b.createServer({
+    _noHolepunching: true, // To ensure it relies only on relaying
+    shareLocalAddress: false, // To help ensure it relies only on relaying (otherwise it can connect directly over LAN, without even trying to holepunch)
     relayThrough: aServer.publicKey
   }, function (socket) {
     lc.pass('server socket opened')


### PR DESCRIPTION
The relay tests weren't really testing anything related to the relays, as the connection stack could connect over the local network, and the relay logic never triggered.

This PR modifies the test where both client and server follow a normal flow, ensuring they cannot connect over LAN or holepunch, also adding explicit checks to ensure this.

Note: I had to add a new, hidden `_noHolepunching` option to  the DHT server, because whenever the holepunch code at the end of the `_addHandshake` function executed, server and client connected directly anyway (https://github.com/holepunchto/hyperdht/blob/66341e7f028189d1418c1ec49635b14d208a26f1/lib/server.js#L402-L407)

This also means that I don't know how to fix the relay tests where the holepunching is cancelled at one side, as those too get saved by that code and currently make no use at all of the relay
