### PR TITLE
Don't loop announce._background when not online

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,6 +48,11 @@ class HyperDHT extends DHT {
     this.on('network-change', () => {
       for (const server of this.listening) server.refresh()
     })
+
+    this.on('network-update', () => {
+      if (!this.online) return
+      for (const server of this.listening) server.notifyOnline()
+    })
   }
 
   connect (remotePublicKey, opts) {

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -1,3 +1,4 @@
+const EventEmitter = require('events')
 const safetyCatch = require('safety-catch')
 const c = require('compact-encoding')
 const Signal = require('signal-promise')
@@ -7,9 +8,12 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 const MIN_ACTIVE = 3
+const MIN_BACKGROUND_LOOP_MS = 3000
 
-module.exports = class Announcer {
+module.exports = class Announcer extends EventEmitter {
   constructor (dht, keyPair, target, opts = {}) {
+    super()
+
     this.dht = dht
     this.keyPair = keyPair
     this.target = target
@@ -80,6 +84,7 @@ module.exports = class Announcer {
 
   async stop () {
     this.stopped = true
+    this.emit('stopping')
     this._sleeper.resume()
     this._resumed.notify()
     await this._active
@@ -95,6 +100,7 @@ module.exports = class Announcer {
 
   async _background () {
     while (!this.dht.destroyed && !this.stopped) {
+      const startTime = Date.now()
       try {
         this._refreshing = false
 
@@ -119,6 +125,18 @@ module.exports = class Announcer {
         if (!this.stopped) await this._runUpdate()
       } catch (err) {
         safetyCatch(err)
+      }
+
+      const msRuntime = Date.now() - startTime
+      if (!this.stopped && !this.suspended && msRuntime < MIN_BACKGROUND_LOOP_MS) {
+        await new Promise(resolve => {
+          const timer = setTimeout(resolve, MIN_BACKGROUND_LOOP_MS - msRuntime)
+          this.on('stopping', () => {
+            clearTimeout(timer)
+            resolve()
+          })
+        }
+        )
       }
     }
   }

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -1,4 +1,3 @@
-const EventEmitter = require('events')
 const safetyCatch = require('safety-catch')
 const c = require('compact-encoding')
 const Signal = require('signal-promise')
@@ -8,12 +7,9 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 const MIN_ACTIVE = 3
-const MIN_BACKGROUND_LOOP_MS = 3000
 
-module.exports = class Announcer extends EventEmitter {
+module.exports = class Announcer {
   constructor (dht, keyPair, target, opts = {}) {
-    super()
-
     this.dht = dht
     this.keyPair = keyPair
     this.target = target
@@ -28,6 +24,7 @@ module.exports = class Announcer extends EventEmitter {
     this._active = null
     this._sleeper = new Sleeper()
     this._resumed = new Signal()
+    this.online = new Signal()
     this._signAnnounce = opts.signAnnounce || Persistent.signAnnounce
     this._signUnannounce = opts.signUnannounce || Persistent.signUnannounce
     this._updating = null
@@ -50,6 +47,10 @@ module.exports = class Announcer extends EventEmitter {
   async suspend () {
     if (this.suspended) return
     this.suspended = true
+
+    // Suspend has its own sleep logic
+    // so we don't want to hang on this one
+    this.online.notify()
 
     if (this._activeQuery) this._activeQuery.destroy()
 
@@ -84,7 +85,7 @@ module.exports = class Announcer extends EventEmitter {
 
   async stop () {
     this.stopped = true
-    this.emit('stopping')
+    this.online.notify() // Break out of the _background loop if we're offline
     this._sleeper.resume()
     this._resumed.notify()
     await this._active
@@ -100,7 +101,6 @@ module.exports = class Announcer extends EventEmitter {
 
   async _background () {
     while (!this.dht.destroyed && !this.stopped) {
-      const startTime = Date.now()
       try {
         this._refreshing = false
 
@@ -123,20 +123,14 @@ module.exports = class Announcer extends EventEmitter {
         while (!this.stopped && this.suspended) await this._resumed.wait()
 
         if (!this.stopped) await this._runUpdate()
+
+        while (!this.dht.online && !this.stopped && !this.suspended) {
+          // Being offline can make _background repeat very quickly
+          // So wait until we're back online
+          await this.online.wait()
+        }
       } catch (err) {
         safetyCatch(err)
-      }
-
-      const msRuntime = Date.now() - startTime
-      if (!this.stopped && !this.suspended && msRuntime < MIN_BACKGROUND_LOOP_MS) {
-        await new Promise(resolve => {
-          const timer = setTimeout(resolve, MIN_BACKGROUND_LOOP_MS - msRuntime)
-          this.on('stopping', () => {
-            clearTimeout(timer)
-            resolve()
-          })
-        }
-        )
       }
     }
   }

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -18,13 +18,13 @@ module.exports = class Announcer {
     this.stopped = false
     this.suspended = false
     this.record = c.encode(m.peer, { publicKey: keyPair.publicKey, relayAddresses: [] })
+    this.online = new Signal()
 
     this._refreshing = false
     this._closestNodes = null
     this._active = null
     this._sleeper = new Sleeper()
     this._resumed = new Signal()
-    this.online = new Signal()
     this._signAnnounce = opts.signAnnounce || Persistent.signAnnounce
     this._signUnannounce = opts.signUnannounce || Persistent.signUnannounce
     this._updating = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -187,6 +187,10 @@ module.exports = class Server extends EventEmitter {
     if (this._announcer) this._announcer.refresh()
   }
 
+  notifyOnline () {
+    if (this._announcer) this._announcer.online.notify()
+  }
+
   _localAddresses () {
     return this.dht.validateLocalAddresses(Holepuncher.localAddresses(this.dht.io.serverSocket))
   }


### PR DESCRIPTION
This fixes an error where the announcer's `_background` enters in an almost-sync loop when internet connection is lost.

<strike>I could have solved it by rate limiting `_runUpdate`, but limiting `_background` itself felt simple and generic (in case another sync loop can be triggered).

I'm not 100% clear yet on how it interacts with the suspend/resume logic, but it should never hang more than 3s.</strike>

=> Solved with another approach

The exact error flow is:
- Internet connection is lost
- ...
- A `_background` iteration starts, and fails to ping anyone, so skips to the outer loop and calls `_update` https://github.com/holepunchto/hyperdht/blob/0c6957fcb61ef3d594da0ef836e25f06e0a95c73/lib/announcer.js#L110
- `_update` runs `dht.findPeer()`. The query doesn't find anyone in its table, and tries to contact the 3 bootstrap nodes (https://github.com/holepunchto/dht-rpc/blob/704a1bd2869cfc89bde53f625819f9dbf0091c4c/lib/query.js#L108-L110)
- This quickly fails, because UDX throws due to DNS resolution failure (swallowed here: https://github.com/holepunchto/hyperdht/blob/0c6957fcb61ef3d594da0ef836e25f06e0a95c73/lib/announcer.js#L139-L143)
=> `_background` instantly restarts, and keeps looping until internet connection is restored

The main symptom is that many DNS queries/second are being sent (systemd-resolved on Linux, or mDNSResponder on mac show high CPU usage).