### PR TITLE
Group opts.holepunch-option processing together for clarity

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -28,6 +28,7 @@ module.exports = class Server extends EventEmitter {
     this.closed = false
     this.firewall = opts.firewall || (() => false)
     this.holepunch = opts.holepunch || (() => true)
+    this._neverPunch = opts.holepunch === false // useful for fully disabling punching
     this.relayThrough = opts.relayThrough || null
     this.pool = opts.pool || null
     this.createHandshake = opts.createHandshake || defaultCreateHandshake
@@ -37,7 +38,6 @@ module.exports = class Server extends EventEmitter {
 
     this._shareLocalAddress = opts.shareLocalAddress !== false
     this._reusableSocket = !!opts.reusableSocket
-    this._neverPunch = opts.holepunch === false // useful for fully disabling punching
     this._keyPair = null
     this._announcer = null
     this._connects = new Map()


### PR DESCRIPTION
This way the contract of `opts.holepunch` is clearer from the code (that it can be either a function or the boolean false).

The disadvantage is that the public/private properties are no longer grouped then, but I think it's clearer this way. Feel free to close unmerged though