### PR TITLE
add connectionKeepAlive opt

### DIFF
--- a/index.js
+++ b/index.js
@@ -66,8 +66,6 @@ class HyperDHT extends DHT {
   createServer (opts, onconnection) {
     if (typeof opts === 'function') return this.createServer({}, opts)
     if (opts && opts.onconnection) onconnection = opts.onconnection
-    opts = { connectionKeepAlive: this.connectionKeepAlive, ...opts }
-
     const s = new Server(this, opts)
     if (onconnection) s.on('connection', onconnection)
     return s

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ class HyperDHT extends DHT {
     this.defaultKeyPair = opts.keyPair || createKeyPair(opts.seed)
     this.listening = new Set()
     this.tracer = createTracer(this)
+    this.connectionKeepAlive = opts.connectionKeepAlive || 0
 
     this._router = new Router(this, router)
     this._socketPool = new SocketPool(this, opts.host || '0.0.0.0')
@@ -65,6 +66,8 @@ class HyperDHT extends DHT {
   createServer (opts, onconnection) {
     if (typeof opts === 'function') return this.createServer({}, opts)
     if (opts && opts.onconnection) onconnection = opts.onconnection
+    opts = { connectionKeepAlive: this.connectionKeepAlive, ...opts }
+
     const s = new Server(this, opts)
     if (onconnection) s.on('connection', onconnection)
     return s

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -44,6 +44,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     remotePublicKey: publicKey,
     autoStart: false
   })
+  encryptedSocket.setKeepAlive(dht.connectionKeepAlive)
 
   if (pool) pool._attachStream(encryptedSocket, false)
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,6 +32,7 @@ module.exports = class Server extends EventEmitter {
     this.pool = opts.pool || null
     this.createHandshake = opts.createHandshake || defaultCreateHandshake
     this.createSecretStream = opts.createSecretStream || defaultCreateSecretStream
+    this.connectionKeepAlive = opts.connectionKeepAlive
     this.suspended = false
     this.tracer = createTracer(this, { parent: dht.tracer })
 
@@ -315,6 +316,7 @@ module.exports = class Server extends EventEmitter {
             : hs.rawStream
 
           hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
+          hs.encryptedSocket.setKeepAlive(this.connectionKeepAlive)
 
           this.onconnection(hs.encryptedSocket)
         }

--- a/lib/server.js
+++ b/lib/server.js
@@ -32,7 +32,6 @@ module.exports = class Server extends EventEmitter {
     this.pool = opts.pool || null
     this.createHandshake = opts.createHandshake || defaultCreateHandshake
     this.createSecretStream = opts.createSecretStream || defaultCreateSecretStream
-    this.connectionKeepAlive = opts.connectionKeepAlive
     this.suspended = false
     this.tracer = createTracer(this, { parent: dht.tracer })
 
@@ -316,7 +315,7 @@ module.exports = class Server extends EventEmitter {
             : hs.rawStream
 
           hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
-          hs.encryptedSocket.setKeepAlive(this.connectionKeepAlive)
+          hs.encryptedSocket.setKeepAlive(this.dht.connectionKeepAlive)
 
           this.onconnection(hs.encryptedSocket)
         }


### PR DESCRIPTION
TODO's before marking ready:
- Should the keepAlives for the relays use the passed-in value if non-0, or remain fixed at 5s? (https://github.com/holepunchto/hyperdht/blob/79eea93b25b975715a769d2f3440994224fab7d3/lib/server.js#L613 and https://github.com/holepunchto/hyperdht/blob/79eea93b25b975715a769d2f3440994224fab7d3/lib/connect.js#L693)
- Cut a hyperswarm-secret-stream release with https://github.com/holepunchto/hyperswarm-secret-stream/pull/30 so the tests don't rely on a private prop
