### PR TITLE
add timestamp to handshake

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -414,8 +414,7 @@ async function connectThroughNode (c, address, socket) {
     serverAddress,
     payload
   }
-  c.encryptedSocket.userData ??= {}
-  c.encryptedSocket.userData.timestamp = payload.timestamp
+  c.encryptedSocket.timestamp = payload.timestamp
 
   c.payload = new SecurePayload(hs.holepunchSecret)
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -81,7 +81,10 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     relaySocket: null,
     relayClient: null,
     relayPaired: false,
-    relayKeepAlive: opts.relayKeepAlive || 5000
+    relayKeepAlive: opts.relayKeepAlive || 5000,
+
+    // Used by the server when tie-breaking between two connections from the same peer
+    timestamp: opts.timestamp ?? -1
   }
 
   // If the raw stream receives an error signal pre connect (ie from the firewall hook), make sure
@@ -374,7 +377,8 @@ async function connectThroughNode (c, address, socket) {
       secretStream: {},
       relayThrough: c.relayThrough
         ? { publicKey: c.relayThrough, token: c.relayToken }
-        : null
+        : null,
+      timestamp: c.timestamp
     })
     if (isDone(c)) return
   }
@@ -410,6 +414,8 @@ async function connectThroughNode (c, address, socket) {
     serverAddress,
     payload
   }
+  c.encryptedSocket.userData ??= {}
+  c.encryptedSocket.userData.timestamp = payload.timestamp
 
   c.payload = new SecurePayload(hs.holepunchSecret)
 

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -162,6 +162,7 @@ exports.noisePayload = {
     if (m.udx) udxInfo.preencode(state, m.udx)
     if (m.secretStream) secretStreamInfo.preencode(state, m.secretStream)
     if (m.relayThrough) relayThroughInfo.preencode(state, m.relayThrough)
+    if (m.timestamp >= 0) c.uint.preencode(state, m.timestamp)
   },
   encode (state, m) {
     let flags = 0
@@ -172,6 +173,7 @@ exports.noisePayload = {
     if (m.udx) flags |= 8
     if (m.secretStream) flags |= 16
     if (m.relayThrough) flags |= 32
+    if (m.timestamp >= 0) flags |= 64
 
     c.uint.encode(state, 1) // version
     c.uint.encode(state, flags)
@@ -184,6 +186,7 @@ exports.noisePayload = {
     if (m.udx) udxInfo.encode(state, m.udx)
     if (m.secretStream) secretStreamInfo.encode(state, m.secretStream)
     if (m.relayThrough) relayThroughInfo.encode(state, m.relayThrough)
+    if (m.timestamp >= 0) c.uint.encode(state, m.timestamp)
   },
   decode (state) {
     const version = c.uint.decode(state)
@@ -200,7 +203,8 @@ exports.noisePayload = {
         addresses6: [],
         udx: null,
         secretStream: null,
-        relayThrough: null
+        relayThrough: null,
+        timestamp: -1
       }
     }
 
@@ -215,7 +219,8 @@ exports.noisePayload = {
       addresses6: (flags & 4) !== 0 ? ipv6Array.decode(state) : [],
       udx: (flags & 8) !== 0 ? udxInfo.decode(state) : null,
       secretStream: (flags & 16) !== 0 ? secretStreamInfo.decode(state) : null,
-      relayThrough: (flags & 32) !== 0 ? relayThroughInfo.decode(state) : null
+      relayThrough: (flags & 32) !== 0 ? relayThroughInfo.decode(state) : null,
+      timestamp: (flags & 64) !== 0 ? c.uint.decode(state) : -1
     }
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -162,7 +162,7 @@ exports.noisePayload = {
     if (m.udx) udxInfo.preencode(state, m.udx)
     if (m.secretStream) secretStreamInfo.preencode(state, m.secretStream)
     if (m.relayThrough) relayThroughInfo.preencode(state, m.relayThrough)
-    if (m.timestamp >= 0) c.uint.preencode(state, m.timestamp)
+    if (m.timestamp > 0) c.uint.preencode(state, m.timestamp)
   },
   encode (state, m) {
     let flags = 0

--- a/lib/server.js
+++ b/lib/server.js
@@ -320,6 +320,8 @@ module.exports = class Server extends EventEmitter {
             keepAlive: this.dht.connectionKeepAlive
           })
 
+          hs.encryptedSocket.userData ??= {}
+          hs.encryptedSocket.userData.timestamp = remotePayload.timestamp
           this.onconnection(hs.encryptedSocket)
         }
 
@@ -355,7 +357,8 @@ module.exports = class Server extends EventEmitter {
         secretStream: {},
         relayThrough: relayThrough
           ? { publicKey: relayThrough, token: hs.relayToken }
-          : null
+          : null,
+        timestamp: Date.now()
       })
     } catch (err) {
       safetyCatch(err)
@@ -650,6 +653,8 @@ module.exports = class Server extends EventEmitter {
 
         hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
 
+        hs.encryptedSocket.userData ??= {}
+        hs.encryptedSocket.userData.timestamp = remotePayload.timestamp
         this.onconnection(hs.encryptedSocket)
       })
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -320,8 +320,7 @@ module.exports = class Server extends EventEmitter {
             keepAlive: this.dht.connectionKeepAlive
           })
 
-          hs.encryptedSocket.userData ??= {}
-          hs.encryptedSocket.userData.timestamp = remotePayload.timestamp
+          hs.encryptedSocket.timestamp = remotePayload.timestamp
           this.onconnection(hs.encryptedSocket)
         }
 
@@ -653,8 +652,7 @@ module.exports = class Server extends EventEmitter {
 
         hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
 
-        hs.encryptedSocket.userData ??= {}
-        hs.encryptedSocket.userData.timestamp = remotePayload.timestamp
+        hs.encryptedSocket.timestamp = remotePayload.timestamp
         this.onconnection(hs.encryptedSocket)
       })
 

--- a/test/messages.js
+++ b/test/messages.js
@@ -14,7 +14,8 @@ test('basic noise payload', function (t) {
     addresses6: [],
     udx: null,
     secretStream: null,
-    relayThrough: null
+    relayThrough: null,
+    timestamp: -1
   }
 
   m.noisePayload.preencode(state, c)
@@ -56,7 +57,8 @@ test('noise payload with holepunch and addresses', function (t) {
     addresses6: [],
     udx: null,
     secretStream: null,
-    relayThrough: null
+    relayThrough: null,
+    timestamp: -1
   }
 
   m.noisePayload.preencode(state, c)
@@ -87,7 +89,8 @@ test('noise payload only addresses', function (t) {
     addresses6: [],
     udx: null,
     secretStream: null,
-    relayThrough: null
+    relayThrough: null,
+    timestamp: -1
   }
 
   m.noisePayload.preencode(state, c)
@@ -118,7 +121,8 @@ test('noise payload ipv6', function (t) {
     }],
     udx: null,
     secretStream: null,
-    relayThrough: null
+    relayThrough: null,
+    timestamp: -1
   }
 
   m.noisePayload.preencode(state, c)
@@ -150,8 +154,38 @@ test('noise payload newer version', function (t) {
     addresses6: [],
     udx: null,
     secretStream: null,
-    relayThrough: null
+    relayThrough: null,
+    timestamp: -1
   })
+})
+
+test('noise payload timestamp', function (t) {
+  const state = { start: 0, end: 0, buffer: null }
+
+  const c = {
+    version: 1,
+    error: 0,
+    firewall: 2,
+    holepunch: null,
+    addresses4: [],
+    addresses6: [],
+    udx: null,
+    secretStream: null,
+    relayThrough: null,
+    timestamp: Date.now()
+  }
+
+  m.noisePayload.preencode(state, c)
+
+  state.buffer = b4a.allocUnsafe(state.end)
+  m.noisePayload.encode(state, c)
+
+  state.start = 0
+
+  const d = m.noisePayload.decode(state)
+
+  t.is(state.start, state.end)
+  t.alike(d, c)
 })
 
 test('basic holepunch payload', function (t) {


### PR DESCRIPTION
Supercedes #167 . It's better because:
- it invalidates old streams without requiring any old state, meaning if the program crashes and restarts, it'll invalidate any old streams as long as `timestamp` is  monotonically increasing ¹ ²
- it's also simpler and requires less book-keeping code in `hyperswarm`
- a timestamp is shorter than a noise stream id
- a timestamp is the same length as a udx stream id, but doesn't suffer from relays changing the udx stream id

¹  `Date.now()` is _not_ guaranteed to be monotonically increasing, but since fast reconnects are not mission critical, it should suffice, since it'll succeed "all" the time for practical purposes.

² According to [MDN](https://developer.mozilla.org/en-US/docs/Web/API/Performance/timeOrigin), `performance.timeOrigin + performance.now()` _is_ guaranteed to be monotonically increasing. But I don't think the `performance` global is available in `bare` JS environments.