### PR TITLE
add a 'relaying' event to connections

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -421,7 +421,6 @@ async function connectThroughNode (c, address, socket) {
 
     if (c.rawStream.connected) {
       c.rawStream.once('remote-changed', () => {
-        c.dht.tracer.trace('remote-changed', { relay: c.encryptedSocket.relay })
         this.encryptedSocket.emit('unrelay', c.encryptedSocket.relay)
       })
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
@@ -740,7 +739,6 @@ function relayConnection (c, relayThrough, payload, hs) {
   }
 
   function onabort (err) {
-    c.dht.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
     if (c.relayTimeout) clearRelayTimeout(c)
     const socket = c.relaySocket
     c.relayToken = null

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -29,6 +29,7 @@ const {
   RELAY_ABORTED,
   SUSPENDED
 } = require('./errors')
+const RelayState = require('./relay-state')
 
 module.exports = function connect (dht, publicKey, opts = {}) {
   dht.tracer.trace('connect', { publicKey, options: opts })
@@ -101,6 +102,8 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     c.session.destroy()
     c.sleeper.resume()
   })
+
+  encryptedSocket.relay = new RelayState()
 
   // Safe to run in the background - never throws
   if (dht.suspended) encryptedSocket.destroy(SUSPENDED())
@@ -419,12 +422,6 @@ async function connectThroughNode (c, address, socket) {
     if (c.rawStream.connected) {
       c.rawStream.once('remote-changed', () => {
         c.dht.tracer.trace('remote-changed', { relay: c.encryptedSocket.relay })
-        c.encryptedSocket.relay = {
-          relaying: false,
-          relayPaired: false,
-          relayThrough: null,
-          remotePublicKey: null
-        }
         this.encryptedSocket.emit('unrelay', c.encryptedSocket.relay)
       })
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
@@ -701,12 +698,8 @@ function relayConnection (c, relayThrough, payload, hs) {
     token = c.relayToken
   }
 
-  c.encryptedSocket.relay = {
-    relaying: true,
-    relayPaired: false,
-    relayThrough: publicKey,
-    remotePublicKey: c.remotePublicKey
-  }
+  c.encryptedSocket.relay.relayThrough = publicKey
+  c.encryptedSocket.relay.remotePublicKey = c.remotePublicKey
   c.relayToken = token
   c.relaySocket = c.dht.connect(publicKey)
   c.relaySocket.setKeepAlive(c.relayKeepAlive)
@@ -717,6 +710,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     .pair(isInitiator, token, c.rawStream)
     .on('error', onabort)
     .on('data', ondata)
+  c.encryptedSocket.relay.pairing()
 
   function ondata (remoteId) {
     if (c.relayTimeout) clearRelayTimeout(c)
@@ -726,8 +720,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     }
 
     c.relayPaired = true
-    c.encryptedSocket.relay.relayPaired = true
-    c.encryptedSocket.emit('relay', c.encryptedSocket.relay)
+    c.encryptedSocket.relay.paired()
 
     const {
       remotePort,
@@ -752,13 +745,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     const socket = c.relaySocket
     c.relayToken = null
     c.relaySocket = null
-    c.encryptedSocket.relay = {
-      relaying: false,
-      relayPaired: false,
-      relayThrough: null,
-      remotePublicKey: null
-    }
-    c.encryptedSocket.emit('relay-aborted', c.encryptedSocket.relay)
+    c.encryptedSocket.relay.abort()
     if (socket) socket.destroy()
     maybeDestroyEncryptedSocket(c, err || RELAY_ABORTED())
   }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -743,7 +743,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     const socket = c.relaySocket
     c.relayToken = null
     c.relaySocket = null
-    c.encryptedSocket.relay.abort()
+    c.encryptedSocket.relay.close()
     if (socket) socket.destroy()
     maybeDestroyEncryptedSocket(c, err || RELAY_ABORTED())
   }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,3 +1,5 @@
+/** @import HyperDHT from '../index' */
+/** @import UDXStream from 'udx-native/lib/stream' */
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const b4a = require('b4a')
 const relay = require('blind-relay')
@@ -30,6 +32,12 @@ const {
   SUSPENDED
 } = require('./errors')
 
+/**
+ * @param {HyperDHT} dht
+ * @param {*} publicKey
+ * @param {*} opts
+ * @returns
+ */
 module.exports = function connect (dht, publicKey, opts = {}) {
   dht.tracer.trace('connect', { publicKey, options: opts })
 
@@ -414,10 +422,24 @@ async function connectThroughNode (c, address, socket) {
   c.payload = new SecurePayload(hs.holepunchSecret)
 
   c.onsocket = function (socket, port, host) {
-    if (c.rawStream === null) return // Already hole punched
+    /** @type {UDXStream} */
+    const rawStream = c.rawStream
+    if (rawStream === null) return // Already hole punched
 
-    if (c.rawStream.connected) {
-      const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
+    if (rawStream.connected) {
+      rawStream.once('remote-changed', () => {
+        // TODO: ask @mafintosh if this is correct
+        c.encryptedSocket.relay = {
+          relaying: false,
+          relayPaired: false,
+          relayThrough: null,
+          remotePublicKey: null
+        }
+        // Note - this is really an "un-relay" event but subscribers should know
+        // to look at the .relay.relaying property
+        this.encryptedSocket.emit('relay', c.encryptedSocket.relay)
+      })
+      const remoteChanging = rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
 
       if (remoteChanging) remoteChanging.catch(safetyCatch)
     } else {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -700,6 +700,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     publicKey = relayThrough
     token = c.relayToken
   }
+
   c.encryptedSocket.relay = {
     relaying: true,
     relayPaired: false,

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -422,12 +422,10 @@ async function connectThroughNode (c, address, socket) {
   c.payload = new SecurePayload(hs.holepunchSecret)
 
   c.onsocket = function (socket, port, host) {
-    /** @type {UDXStream} */
-    const rawStream = c.rawStream
-    if (rawStream === null) return // Already hole punched
+    if (c.rawStream === null) return // Already hole punched
 
-    if (rawStream.connected) {
-      rawStream.once('remote-changed', () => {
+    if (c.rawStream.connected) {
+      c.rawStream.once('remote-changed', () => {
         // TODO: ask @mafintosh if this is correct
         c.encryptedSocket.relay = {
           relaying: false,
@@ -439,7 +437,7 @@ async function connectThroughNode (c, address, socket) {
         // to look at the .relay.relaying property
         this.encryptedSocket.emit('relay', c.encryptedSocket.relay)
       })
-      const remoteChanging = rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
+      const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
 
       if (remoteChanging) remoteChanging.catch(safetyCatch)
     } else {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -690,7 +690,13 @@ function relayConnection (c, relayThrough, payload, hs) {
     publicKey = relayThrough
     token = c.relayToken
   }
-  c.encryptedSocket.emit('relaying', { relayThrough: publicKey })
+  c.encryptedSocket.relay = {
+    relaying: true,
+    relayPaired: false,
+    relayThrough: publicKey,
+    remotePublicKey: c.remotePublicKey
+  }
+  c.encryptedSocket.emit('relay', c.encryptedSocket.relay)
 
   c.relayToken = token
   c.relaySocket = c.dht.connect(publicKey)
@@ -711,6 +717,8 @@ function relayConnection (c, relayThrough, payload, hs) {
     }
 
     c.relayPaired = true
+    c.encryptedSocket.relay.relayPaired = true
+    c.encryptedSocket.emit('relay', c.encryptedSocket.relay)
 
     const {
       remotePort,

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -690,6 +690,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     publicKey = relayThrough
     token = c.relayToken
   }
+  c.encryptedSocket.emit('relaying', { relayThrough: publicKey })
 
   c.relayToken = token
   c.relaySocket = c.dht.connect(publicKey)

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -425,8 +425,9 @@ async function connectThroughNode (c, address, socket) {
     if (c.rawStream === null) return // Already hole punched
 
     if (c.rawStream.connected) {
+      // TODO: ask @mafintosh if this "un-relaying" logic is correct
       c.rawStream.once('remote-changed', () => {
-        // TODO: ask @mafintosh if this is correct
+        c.dht.tracer.trace('remote-changed', { relay: c.encryptedSocket.relay })
         c.encryptedSocket.relay = {
           relaying: false,
           relayPaired: false,
@@ -717,6 +718,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     remotePublicKey: c.remotePublicKey
   }
   c.encryptedSocket.emit('relay', c.encryptedSocket.relay)
+  c.dht.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
 
   c.relayToken = token
   c.relaySocket = c.dht.connect(publicKey)
@@ -730,6 +732,7 @@ function relayConnection (c, relayThrough, payload, hs) {
     .on('data', ondata)
 
   function ondata (remoteId) {
+    c.dht.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
     if (c.relayTimeout) clearRelayTimeout(c)
     if (c.rawStream === null) {
       onabort(null)
@@ -758,10 +761,17 @@ function relayConnection (c, relayThrough, payload, hs) {
   }
 
   function onabort (err) {
+    c.dht.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
     if (c.relayTimeout) clearRelayTimeout(c)
     const socket = c.relaySocket
     c.relayToken = null
     c.relaySocket = null
+    c.encryptedSocket.relay = {
+      relaying: false,
+      relayPaired: false,
+      relayThrough: null,
+      remotePublicKey: null
+    }
     if (socket) socket.destroy()
     maybeDestroyEncryptedSocket(c, err || RELAY_ABORTED())
   }
@@ -778,6 +788,7 @@ function clearRelayTimeout (c) {
 }
 
 function destroyPuncher (c) {
+  c.dht.tracer.trace('destroy-puncher')
   if (c.puncher) c.puncher.destroy()
   c.session.destroy()
 }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,5 +1,3 @@
-/** @import HyperDHT from '../index' */
-/** @import UDXStream from 'udx-native/lib/stream' */
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const b4a = require('b4a')
 const relay = require('blind-relay')
@@ -32,12 +30,6 @@ const {
   SUSPENDED
 } = require('./errors')
 
-/**
- * @param {HyperDHT} dht
- * @param {*} publicKey
- * @param {*} opts
- * @returns
- */
 module.exports = function connect (dht, publicKey, opts = {}) {
   dht.tracer.trace('connect', { publicKey, options: opts })
 
@@ -425,7 +417,6 @@ async function connectThroughNode (c, address, socket) {
     if (c.rawStream === null) return // Already hole punched
 
     if (c.rawStream.connected) {
-      // TODO: ask @mafintosh if this "un-relaying" logic is correct
       c.rawStream.once('remote-changed', () => {
         c.dht.tracer.trace('remote-changed', { relay: c.encryptedSocket.relay })
         c.encryptedSocket.relay = {
@@ -434,9 +425,7 @@ async function connectThroughNode (c, address, socket) {
           relayThrough: null,
           remotePublicKey: null
         }
-        // Note - this is really an "un-relay" event but subscribers should know
-        // to look at the .relay.relaying property
-        this.encryptedSocket.emit('relay', c.encryptedSocket.relay)
+        this.encryptedSocket.emit('unrelay', c.encryptedSocket.relay)
       })
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
 
@@ -717,9 +706,6 @@ function relayConnection (c, relayThrough, payload, hs) {
     relayThrough: publicKey,
     remotePublicKey: c.remotePublicKey
   }
-  c.encryptedSocket.emit('relay', c.encryptedSocket.relay)
-  c.dht.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
-
   c.relayToken = token
   c.relaySocket = c.dht.connect(publicKey)
   c.relaySocket.setKeepAlive(c.relayKeepAlive)
@@ -732,7 +718,6 @@ function relayConnection (c, relayThrough, payload, hs) {
     .on('data', ondata)
 
   function ondata (remoteId) {
-    c.dht.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: c.remotePublicKey })
     if (c.relayTimeout) clearRelayTimeout(c)
     if (c.rawStream === null) {
       onabort(null)
@@ -772,6 +757,7 @@ function relayConnection (c, relayThrough, payload, hs) {
       relayThrough: null,
       remotePublicKey: null
     }
+    c.encryptedSocket.emit('relay-aborted', c.encryptedSocket.relay)
     if (socket) socket.destroy()
     maybeDestroyEncryptedSocket(c, err || RELAY_ABORTED())
   }
@@ -788,7 +774,6 @@ function clearRelayTimeout (c) {
 }
 
 function destroyPuncher (c) {
-  c.dht.tracer.trace('destroy-puncher')
   if (c.puncher) c.puncher.destroy()
   c.session.destroy()
 }

--- a/lib/raw-stream-set.js
+++ b/lib/raw-stream-set.js
@@ -1,9 +1,5 @@
-/** @import HyperDHT from '../index' */
-
 module.exports = class RawStreamSet {
-  /** @param {HyperDHT} dht */
   constructor (dht) {
-    /** @type {HyperDHT} */
     this._dht = dht
 
     this._prefix = 16 - 1 // 16 is the default stream-set side in udx

--- a/lib/raw-stream-set.js
+++ b/lib/raw-stream-set.js
@@ -1,5 +1,9 @@
+/** @import HyperDHT from '../index' */
+
 module.exports = class RawStreamSet {
+  /** @param {HyperDHT} dht */
   constructor (dht) {
+    /** @type {HyperDHT} */
     this._dht = dht
 
     this._prefix = 16 - 1 // 16 is the default stream-set side in udx

--- a/lib/relay-state.js
+++ b/lib/relay-state.js
@@ -1,0 +1,42 @@
+const EventEmitter = require('events')
+
+class RelayState extends EventEmitter {
+  constructor (relayThrough = null, remotePublicKey = null) {
+    super()
+    this.relayThrough = relayThrough
+    this.remotePublicKey = remotePublicKey
+    this.state = RelayState.NOT_STARTED
+  }
+
+  get relaying () {
+    return this.state === RelayState.RELAYING
+  }
+
+  abort () {
+    this.state = RelayState.ABORTED
+    this.emit('abort')
+  }
+
+  pairing () {
+    this.state = RelayState.PAIRING
+    this.emit('pairing')
+  }
+
+  paired () {
+    this.state = RelayState.RELAYING
+    this.emit('relay')
+  }
+
+  unrelay () {
+    this.state = RelayState.NOT_RELAYING
+    this.emit('unrelay')
+  }
+}
+
+RelayState.ABORTED = -1
+RelayState.NOT_STARTED = 1
+RelayState.PAIRING = 2
+RelayState.RELAYING = 3
+RelayState.NOT_RELAYING = 4
+
+module.exports = RelayState

--- a/lib/relay-state.js
+++ b/lib/relay-state.js
@@ -12,9 +12,8 @@ class RelayState extends EventEmitter {
     return this.state === RelayState.RELAYING
   }
 
-  abort () {
-    this.state = RelayState.ABORTED
-    this.emit('abort')
+  close () {
+    this.state = RelayState.CLOSED
   }
 
   pairing () {
@@ -33,10 +32,10 @@ class RelayState extends EventEmitter {
   }
 }
 
-RelayState.ABORTED = -1
 RelayState.NOT_STARTED = 1
 RelayState.PAIRING = 2
 RelayState.RELAYING = 3
 RelayState.NOT_RELAYING = 4
+RelayState.CLOSED = 5
 
 module.exports = RelayState

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ const { isPrivate } = require('bogon')
 const { ALREADY_LISTENING, NODE_DESTROYED } = require('./errors')
 const { createTracer } = require('hypertrace')
 const { getStreamError } = require('streamx')
+const RelayState = require('./relay-state')
 
 const HANDSHAKE_CLEAR_WAIT = 10000
 const HANDSHAKE_INITIAL_TIMEOUT = 10000
@@ -21,8 +22,8 @@ const HANDSHAKE_INITIAL_TIMEOUT = 10000
 module.exports = class Server extends EventEmitter {
   constructor (dht, opts = {}) {
     super()
-    this.dht = dht
 
+    this.dht = dht
     this.target = null
 
     this.closed = false
@@ -308,13 +309,7 @@ module.exports = class Server extends EventEmitter {
         if (hs.rawStream.connected) {
           hs.rawStream.once('remote-changed', () => {
             this.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
-            hs.encryptedSocket.relay = {
-              relaying: false,
-              relayPaired: false,
-              relayThrough: null,
-              remotePublicKey: null
-            }
-            hs.encryptedSocket.emit('unrelay', hs.encryptedSocket.relay)
+            hs.encryptedSocket.relay.unrelay()
           })
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
 
@@ -331,12 +326,7 @@ module.exports = class Server extends EventEmitter {
             keepAlive: this.dht.connectionKeepAlive
           })
 
-          hs.encryptedSocket.relay = {
-            relaying: false,
-            relayPaired: false,
-            relayThrough: null,
-            remotePublicKey: null
-          }
+          hs.encryptedSocket.relay = new RelayState()
 
           this.onconnection(hs.encryptedSocket)
         }
@@ -667,13 +657,8 @@ module.exports = class Server extends EventEmitter {
           : hs.rawStream
 
         hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
-        hs.encryptedSocket.relay = {
-          relaying: true,
-          relayPaired: true,
-          relayThrough: publicKey,
-          remotePublicKey: h.remotePublicKey
-        }
-        hs.encryptedSocket.emit('relay', hs.encryptedSocket.relay)
+        hs.encryptedSocket.relay = new RelayState(publicKey, h.remotePublicKey)
+        hs.encryptedSocket.relay.paired()
 
         this.onconnection(hs.encryptedSocket)
       })
@@ -684,13 +669,7 @@ module.exports = class Server extends EventEmitter {
       const socket = hs.relaySocket
       hs.relayToken = null
       hs.relaySocket = null
-      hs.encryptedSocket.relay = {
-        relaying: false,
-        relayPaired: false,
-        relayThrough: null,
-        remotePublicKey: null
-      }
-      hs.encryptedSocket.emit('relay-aborted', hs.encryptedSocket.relay)
+      hs.encryptedSocket.relay.abort()
       if (socket) socket.destroy()
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -306,8 +306,9 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('error', autoDestroy)
 
         if (hs.rawStream.connected) {
+          // TODO: ask @mafintosh if this "un-relaying" logic is correct
           hs.rawStream.once('remote-changed', () => {
-            // TODO: ask @mafintosh if this is correct
+            hs.dht.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
             hs.encryptedSocket.relay = {
               relaying: false,
               relayPaired: false,
@@ -632,6 +633,7 @@ module.exports = class Server extends EventEmitter {
       relayThrough: publicKey,
       remotePublicKey: h.remotePublicKey
     })
+    hs.dht.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
 
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
@@ -643,6 +645,7 @@ module.exports = class Server extends EventEmitter {
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
+        hs.dht.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
         if (hs.relayTimeout) clearRelayTimeout(hs)
         if (hs.rawStream === null) {
           onabort(null)
@@ -671,7 +674,7 @@ module.exports = class Server extends EventEmitter {
         hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
         hs.encryptedSocket.relay = {
           relaying: true,
-          relayPaired: hs.relayPaired,
+          relayPaired: true,
           relayThrough: publicKey,
           remotePublicKey: h.remotePublicKey
         }
@@ -681,10 +684,17 @@ module.exports = class Server extends EventEmitter {
       })
 
     function onabort () {
+      hs.dht.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null
       hs.relaySocket = null
+      hs.encryptedSocket.relay = {
+        relaying: false,
+        relayPaired: false,
+        relayThrough: null,
+        remotePublicKey: null
+      }
       if (socket) socket.destroy()
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,4 +1,3 @@
-/** @import HyperDHT from '../index' */
 const { EventEmitter } = require('events')
 const safetyCatch = require('safety-catch')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
@@ -22,7 +21,6 @@ const HANDSHAKE_INITIAL_TIMEOUT = 10000
 module.exports = class Server extends EventEmitter {
   constructor (dht, opts = {}) {
     super()
-    /** @type {HyperDHT} */
     this.dht = dht
     this.target = null
 
@@ -307,7 +305,6 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('error', autoDestroy)
 
         if (hs.rawStream.connected) {
-          // TODO: ask @mafintosh if this "un-relaying" logic is correct
           hs.rawStream.once('remote-changed', () => {
             this.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
             hs.encryptedSocket.relay = {
@@ -316,9 +313,7 @@ module.exports = class Server extends EventEmitter {
               relayThrough: null,
               remotePublicKey: null
             }
-            // Note - this is really an "un-relay" event but subscribers should know
-            // to look at the .relay.relaying property
-            hs.encryptedSocket.emit('relay', hs.encryptedSocket.relay)
+            hs.encryptedSocket.emit('unrelay', hs.encryptedSocket.relay)
           })
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
 
@@ -334,6 +329,13 @@ module.exports = class Server extends EventEmitter {
             handshake: h,
             keepAlive: this.dht.connectionKeepAlive
           })
+
+          hs.encryptedSocket.relay = {
+            relaying: false,
+            relayPaired: false,
+            relayThrough: null,
+            remotePublicKey: null
+          }
 
           this.onconnection(hs.encryptedSocket)
         }
@@ -628,14 +630,6 @@ module.exports = class Server extends EventEmitter {
       token = remotePayload.relayThrough.token
     }
 
-    this.emit('relay', {
-      relaying: true,
-      relayPaired: false,
-      relayThrough: publicKey,
-      remotePublicKey: h.remotePublicKey
-    })
-    hs.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
-
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
     hs.relaySocket.setKeepAlive(this.relayKeepAlive)
@@ -646,7 +640,6 @@ module.exports = class Server extends EventEmitter {
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
-        hs.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
         if (hs.relayTimeout) clearRelayTimeout(hs)
         if (hs.rawStream === null) {
           onabort(null)
@@ -679,7 +672,7 @@ module.exports = class Server extends EventEmitter {
           relayThrough: publicKey,
           remotePublicKey: h.remotePublicKey
         }
-        this.emit('relay', hs.encryptedSocket.relay)
+        hs.encryptedSocket.emit('relay', hs.encryptedSocket.relay)
 
         this.onconnection(hs.encryptedSocket)
       })
@@ -696,6 +689,7 @@ module.exports = class Server extends EventEmitter {
         relayThrough: null,
         remotePublicKey: null
       }
+      hs.encryptedSocket.emit('relay-aborted', hs.encryptedSocket.relay)
       if (socket) socket.destroy()
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -22,6 +22,7 @@ module.exports = class Server extends EventEmitter {
   constructor (dht, opts = {}) {
     super()
     this.dht = dht
+
     this.target = null
 
     this.closed = false

--- a/lib/server.js
+++ b/lib/server.js
@@ -308,7 +308,7 @@ module.exports = class Server extends EventEmitter {
         if (hs.rawStream.connected) {
           // TODO: ask @mafintosh if this "un-relaying" logic is correct
           hs.rawStream.once('remote-changed', () => {
-            hs.dht.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
+            this.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
             hs.encryptedSocket.relay = {
               relaying: false,
               relayPaired: false,
@@ -633,7 +633,7 @@ module.exports = class Server extends EventEmitter {
       relayThrough: publicKey,
       remotePublicKey: h.remotePublicKey
     })
-    hs.dht.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
+    this.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
 
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
@@ -645,7 +645,7 @@ module.exports = class Server extends EventEmitter {
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
-        hs.dht.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
+        this.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
         if (hs.relayTimeout) clearRelayTimeout(hs)
         if (hs.rawStream === null) {
           onabort(null)
@@ -684,7 +684,7 @@ module.exports = class Server extends EventEmitter {
       })
 
     function onabort () {
-      hs.dht.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
+      this.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -1,3 +1,4 @@
+/** @import HyperDHT from '../index' */
 const { EventEmitter } = require('events')
 const safetyCatch = require('safety-catch')
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
@@ -21,7 +22,7 @@ const HANDSHAKE_INITIAL_TIMEOUT = 10000
 module.exports = class Server extends EventEmitter {
   constructor (dht, opts = {}) {
     super()
-
+    /** @type {HyperDHT} */
     this.dht = dht
     this.target = null
 
@@ -305,6 +306,18 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('error', autoDestroy)
 
         if (hs.rawStream.connected) {
+          hs.rawStream.once('remote-changed', () => {
+            // TODO: ask @mafintosh if this is correct
+            hs.encryptedSocket.relay = {
+              relaying: false,
+              relayPaired: false,
+              relayThrough: null,
+              remotePublicKey: null
+            }
+            // Note - this is really an "un-relay" event but subscribers should know
+            // to look at the .relay.relaying property
+            hs.encryptedSocket.emit('relay', hs.encryptedSocket.relay)
+          })
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
 
           if (remoteChanging) remoteChanging.catch(safetyCatch)

--- a/lib/server.js
+++ b/lib/server.js
@@ -666,7 +666,7 @@ module.exports = class Server extends EventEmitter {
       const socket = hs.relaySocket
       hs.relayToken = null
       hs.relaySocket = null
-      hs.encryptedSocket.relay.abort()
+      hs.encryptedSocket.relay.close()
       if (socket) socket.destroy()
     }
   }

--- a/lib/server.js
+++ b/lib/server.js
@@ -613,7 +613,12 @@ module.exports = class Server extends EventEmitter {
       token = remotePayload.relayThrough.token
     }
 
-    this.emit('relaying', { publicKey: h.remotePublicKey, relayThrough: publicKey })
+    this.emit('relay', {
+      relaying: true,
+      relayPaired: false,
+      relayThrough: publicKey,
+      remotePublicKey: h.remotePublicKey
+    })
 
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
@@ -651,6 +656,13 @@ module.exports = class Server extends EventEmitter {
           : hs.rawStream
 
         hs.encryptedSocket = this.createSecretStream(false, rawStream, { handshake: h })
+        hs.encryptedSocket.relay = {
+          relaying: true,
+          relayPaired: hs.relayPaired,
+          relayThrough: publicKey,
+          remotePublicKey: h.remotePublicKey
+        }
+        this.emit('relay', hs.encryptedSocket.relay)
 
         this.onconnection(hs.encryptedSocket)
       })

--- a/lib/server.js
+++ b/lib/server.js
@@ -613,6 +613,8 @@ module.exports = class Server extends EventEmitter {
       token = remotePayload.relayThrough.token
     }
 
+    this.emit('relaying', { publicKey: h.remotePublicKey, relayThrough: publicKey })
+
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
     hs.relaySocket.setKeepAlive(this.relayKeepAlive)

--- a/lib/server.js
+++ b/lib/server.js
@@ -222,6 +222,7 @@ module.exports = class Server extends EventEmitter {
       firewalled: true,
       clearing: null,
       onsocket: null,
+      tracer: this.tracer,
 
       // Relay state
       relayTimeout: null,
@@ -633,7 +634,7 @@ module.exports = class Server extends EventEmitter {
       relayThrough: publicKey,
       remotePublicKey: h.remotePublicKey
     })
-    this.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
+    hs.tracer.trace('relay-connect', { relayThrough: publicKey, remotePublicKey: h.remotePublicKey })
 
     hs.relayToken = token
     hs.relaySocket = this.dht.connect(publicKey)
@@ -645,7 +646,7 @@ module.exports = class Server extends EventEmitter {
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
-        this.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
+        hs.tracer.trace('relay-connected', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
         if (hs.relayTimeout) clearRelayTimeout(hs)
         if (hs.rawStream === null) {
           onabort(null)
@@ -684,7 +685,7 @@ module.exports = class Server extends EventEmitter {
       })
 
     function onabort () {
-      this.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
+      hs.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -222,7 +222,6 @@ module.exports = class Server extends EventEmitter {
       firewalled: true,
       clearing: null,
       onsocket: null,
-      tracer: this.tracer,
 
       // Relay state
       relayTimeout: null,
@@ -308,7 +307,6 @@ module.exports = class Server extends EventEmitter {
 
         if (hs.rawStream.connected) {
           hs.rawStream.once('remote-changed', () => {
-            this.tracer.trace('remote-changed', { relay: hs.encryptedSocket.relay })
             hs.encryptedSocket.relay.unrelay()
           })
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
@@ -664,7 +662,6 @@ module.exports = class Server extends EventEmitter {
       })
 
     function onabort () {
-      hs.tracer.trace('relay-aborted', { relayThrough: publicKey, remotePublicKey: hs.remotePublicKey })
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     }
   },
   "dependencies": {
-    "@hyperswarm/secret-stream": "^6.6.0",
+    "@hyperswarm/secret-stream": "^6.6.1",
     "b4a": "^1.3.1",
     "bare-events": "^2.2.0",
     "blind-relay": "^1.3.0",

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -11,7 +11,7 @@ test('relay connections through node, client side', async function (t) {
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(7)
+  lc.plan(5)
 
   const aServer = a.createServer(function (socket) {
     lc.pass('server socket opened')
@@ -54,10 +54,6 @@ test('relay connections through node, client side', async function (t) {
     })
     .end('hello world')
 
-  aSocket.relay.on('abort', () => {
-    lc.pass('relay aborted')
-    lc.is(aSocket.relay.relaying, false)
-  })
   await lc
 
   await a.destroy()
@@ -73,7 +69,7 @@ test('relay connections through node, client side, client aborts hole punch', as
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(5)
 
   const aServer = a.createServer(function (socket) {
     lc.pass('server socket opened')
@@ -116,10 +112,6 @@ test('relay connections through node, client side, client aborts hole punch', as
     })
     .end('hello world')
 
-  aSocket.relay.on('abort', () => {
-    lc.pass('client relay aborted')
-  })
-
   await lc
 
   await a.destroy()
@@ -135,7 +127,7 @@ test('relay connections through node, client side, server aborts hole punch', as
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(5)
 
   const aServer = a.createServer({ holepunch: () => false }, function (socket) {
     lc.pass('server socket opened')
@@ -178,10 +170,6 @@ test('relay connections through node, client side, server aborts hole punch', as
     })
     .end('hello world')
 
-  aSocket.relay.on('abort', () => {
-    lc.pass('client relay aborted')
-  })
-
   await lc
 
   await a.destroy()
@@ -197,7 +185,7 @@ test('relay connections through node, server side', async function (t) {
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(5)
 
   const relay = new RelayServer({
     createStream (opts) {
@@ -240,10 +228,6 @@ test('relay connections through node, server side', async function (t) {
     })
     .end('hello world')
 
-  bSocket.relay.on('abort', () => {
-    lc.pass('client relay aborted')
-  })
-
   await lc
 
   await a.destroy()
@@ -259,7 +243,7 @@ test('relay connections through node, server side, client aborts hole punch', as
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(5)
 
   const relay = new RelayServer({
     createStream (opts) {
@@ -302,10 +286,6 @@ test('relay connections through node, server side, client aborts hole punch', as
     })
     .end('hello world')
 
-  bSocket.relay.on('abort', () => {
-    lc.pass('client relay aborted')
-  })
-
   await lc
 
   await a.destroy()
@@ -321,7 +301,7 @@ test('relay connections through node, server side, server aborts hole punch', as
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(5)
 
   const relay = new RelayServer({
     createStream (opts) {
@@ -363,10 +343,6 @@ test('relay connections through node, server side, server aborts hole punch', as
       lc.pass('client socket closed')
     })
     .end('hello world')
-
-  bSocket.relay.on('abort', () => {
-    lc.pass('client relay aborted')
-  })
 
   await lc
 
@@ -451,9 +427,6 @@ test('relay connections through node, client and server side', async function (t
       lc.alike(bSocket.relay.remotePublicKey, bServer.publicKey)
       lc.alike(bSocket.relay.relayThrough, aServer.publicKey)
     })
-    .on('abort', () => {
-      lc.fail('client relay aborted')
-    })
 
   await lc
 
@@ -470,7 +443,7 @@ test.skip('relay several connections through node with pool', async function (t)
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(12)
+  lc.plan(10)
 
   const aServer = a.createServer(function (socket) {
     lc.pass('server socket opened')
@@ -523,16 +496,8 @@ test.skip('relay several connections through node with pool', async function (t)
           lc.pass('2nd client socket closed')
         })
         .end('hello world')
-
-      aSocket.relay.on('abort', () => {
-        lc.pass('2nd client relay aborted')
-      })
     })
     .end('hello world')
-
-  aSocket.relay.on('abort', () => {
-    lc.pass('1st client relay aborted')
-  })
 
   await lc
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -379,7 +379,7 @@ test('relay connections through node, client and server side', async function (t
   const c = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(6)
+  lc.plan(10)
   const testRelay = t.test('relay server')
   testRelay.plan(2) // One each for the initiator and the follower
   const testRelayInitiator = t.test('relay initiator')
@@ -432,8 +432,12 @@ test('relay connections through node, client and server side', async function (t
   const bSocket = c.connect(bServer.publicKey, { relayThrough: aServer.publicKey })
 
   bSocket
-    .on('relay', () => {
+    .on('relay', (data) => {
       lc.pass('client socket is being relayed')
+      lc.is(data.relaying, true)
+      lc.is(data.relayPaired, true)
+      lc.alike(data.relayThrough, aServer.publicKey)
+      lc.alike(data.remotePublicKey, bServer.publicKey)
     })
     .on('relay-aborted', (data) => {
       lc.fail('client relay aborted')


### PR DESCRIPTION
https://app.asana.com/0/1206774237110658/1207704548548702

Intent - there should be a `.relay` property on connection objects that accurately reflects the relaying state of the connection. And it should fire events when that state changes.

```js
swarm.on('connection', (conn) => {
  function cb () {
    console.log('currently using relay?', conn.relay.relaying)
  }
  conn.relay.on('relay', cb)
  conn.relay.on('unrelay', cb)
}
```