### PR TITLE
Unslab remotePublicKey in connect

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -5,6 +5,7 @@ const DebuggingStream = require('debugging-stream')
 const { isPrivate, isBogon } = require('bogon')
 const safetyCatch = require('safety-catch')
 const { getStreamError } = require('streamx')
+const unslab = require('unslab')
 const Semaphore = require('./semaphore')
 const NoiseWrap = require('./noise-wrap')
 const SecurePayload = require('./secure-payload')
@@ -37,10 +38,12 @@ module.exports = function connect (dht, publicKey, opts = {}) {
 
   if (pool && pool.has(publicKey)) return pool.get(publicKey)
 
+  publicKey = unslab(publicKey)
+
   const keyPair = opts.keyPair || dht.defaultKeyPair
   const relayThrough = selectRelay(opts.relayThrough || null)
   const encryptedSocket = (opts.createSecretStream || defaultCreateSecretStream)(true, null, {
-    publicKey: keyPair.publicKey,
+    publicKey: unslab(keyPair.publicKey),
     remotePublicKey: publicKey,
     autoStart: false,
     keepAlive: dht.connectionKeepAlive

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -43,7 +43,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
   const keyPair = opts.keyPair || dht.defaultKeyPair
   const relayThrough = selectRelay(opts.relayThrough || null)
   const encryptedSocket = (opts.createSecretStream || defaultCreateSecretStream)(true, null, {
-    publicKey: unslab(keyPair.publicKey),
+    publicKey: keyPair.publicKey,
     remotePublicKey: publicKey,
     autoStart: false,
     keepAlive: dht.connectionKeepAlive

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "signal-promise": "^1.0.3",
     "sodium-universal": "^4.0.0",
     "streamx": "^2.16.1",
+    "unslab": "^1.3.0",
     "xache": "^1.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Currently causes a memleak in hyperswarm-secret-stream (its `publicKey` retains ~8kb buffers, its `remotePublicKey` retains ~68kb buffers)