### PR TITLE
Don't spam refresh if there are <3 nodes to ping

### DIFF
--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -113,7 +113,9 @@ module.exports = class Announcer {
           }
 
           const active = await resolved(pings)
-          if (active < MIN_ACTIVE) this.refresh() // we lost too many relay nodes, retry all
+          if (active < Math.min(pings.length, MIN_ACTIVE)) {
+            this.refresh() // we lost too many relay nodes, retry all
+          }
 
           if (this.stopped) return
 


### PR DESCRIPTION
Mostly relevant for small testnets: the announcer's background while was running a lot if there were fewer than 3 nodes to ping, because it continuously triggered refresh.