### PR TITLE
Unslab hash where relevant

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -63,7 +63,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     relayAddresses: opts.relayAddresses || [],
     pool,
     round: 0,
-    target: hash(publicKey),
+    target: hash(publicKey, b4a.allocUnsafeSlow),
     remotePublicKey: publicKey,
     reusableSocket: !!opts.reusableSocket,
     handshake: (opts.createHandshake || defaultCreateHandshake)(keyPair, publicKey),

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -12,7 +12,7 @@ const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
 const Sleeper = require('./sleeper')
 const { FIREWALL, ERROR } = require('./constants')
-const { hash } = require('./crypto')
+const { unslabbedHash } = require('./crypto')
 const {
   CANNOT_HOLEPUNCH,
   HANDSHAKE_INVALID,
@@ -63,7 +63,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
     relayAddresses: opts.relayAddresses || [],
     pool,
     round: 0,
-    target: hash(publicKey, b4a.allocUnsafeSlow),
+    target: unslabbedHash(publicKey),
     remotePublicKey: publicKey,
     reusableSocket: !!opts.reusableSocket,
     handshake: (opts.createHandshake || defaultCreateHandshake)(keyPair, publicKey),

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,8 +1,14 @@
 const sodium = require('sodium-universal')
 const b4a = require('b4a')
 
-function hash (data, alloc = b4a.allocUnsafe) {
-  const out = alloc(32)
+function hash (data) {
+  const out = b4a.allocUnsafe(32)
+  sodium.crypto_generichash(out, data)
+  return out
+}
+
+function unslabbedHash (data) {
+  const out = b4a.allocUnsafeSlow(32)
   sodium.crypto_generichash(out, data)
   return out
 }
@@ -17,5 +23,6 @@ function createKeyPair (seed) {
 
 module.exports = {
   hash,
+  unslabbedHash,
   createKeyPair
 }

--- a/lib/crypto.js
+++ b/lib/crypto.js
@@ -1,8 +1,8 @@
 const sodium = require('sodium-universal')
 const b4a = require('b4a')
 
-function hash (data) {
-  const out = b4a.allocUnsafe(32)
+function hash (data, alloc = b4a.allocUnsafe) {
+  const out = alloc(32)
   sodium.crypto_generichash(out, data)
   return out
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -164,7 +164,7 @@ module.exports = class Server extends EventEmitter {
     await this.dht.bind()
     if (this._closing) return
 
-    this.target = hash(keyPair.publicKey)
+    this.target = hash(keyPair.publicKey, b4a.allocUnsafeSlow)
 
     this._keyPair = keyPair
     this._announcer = new Announcer(this.dht, keyPair, this.target, opts)

--- a/lib/server.js
+++ b/lib/server.js
@@ -6,7 +6,7 @@ const relay = require('blind-relay')
 const NoiseWrap = require('./noise-wrap')
 const Announcer = require('./announcer')
 const { FIREWALL, ERROR } = require('./constants')
-const { hash } = require('./crypto')
+const { unslabbedHash } = require('./crypto')
 const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
 const DebuggingStream = require('debugging-stream')
@@ -164,7 +164,7 @@ module.exports = class Server extends EventEmitter {
     await this.dht.bind()
     if (this._closing) return
 
-    this.target = hash(keyPair.publicKey, b4a.allocUnsafeSlow)
+    this.target = unslabbedHash(keyPair.publicKey)
 
     this._keyPair = keyPair
     this._announcer = new Announcer(this.dht, keyPair, this.target, opts)


### PR DESCRIPTION
Each usage of hash currently retains the 8kb buffer. This PR exposes an option not to.

The change in server isn't very relevant (just one per server), but the one in connect does matter a bit (one per connection)