### PR TITLE
Populate DHT with Pear.config.dht

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,7 +22,13 @@ class HyperDHT extends DHT {
     const port = opts.port || 49737
     const bootstrap = opts.bootstrap || BOOTSTRAP_NODES
 
-    super({ ...opts, port, bootstrap, addNode })
+    super({ ...opts, port, bootstrap, shouldAddNode })
+
+    if (Array.isArray(global?.Pear?.config?.dht)) {
+      global.Pear.config.dht.forEach(node => {
+        this.addNode(node)
+      })
+    }
 
     const { router, persistent } = defaultCacheOpts(opts)
 
@@ -543,7 +549,7 @@ function toRange (n) {
   return typeof n === 'number' ? [n, n] : n
 }
 
-function addNode (node) {
+function shouldAddNode (node) {
   // always skip these testnet nodes that got mixed in by accident, until they get updated
   return !(node.port === 49738 && (node.host === '134.209.28.98' || node.host === '167.99.142.185')) &&
     !(node.port === 9400 && node.host === '35.233.47.252') && !(node.host === '150.136.142.116')

--- a/index.js
+++ b/index.js
@@ -21,10 +21,11 @@ class HyperDHT extends DHT {
   constructor (opts = {}) {
     const port = opts.port || 49737
     const bootstrap = opts.bootstrap || BOOTSTRAP_NODES
+    const knownNodes = opts.knownNodes || KNOWN_NODES
 
     super({ ...opts, port, bootstrap, filterNode })
 
-    for (const node of KNOWN_NODES) this.addNode(node)
+    for (const node of knownNodes) this.addNode(node)
 
     const { router, persistent } = defaultCacheOpts(opts)
 

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class HyperDHT extends DHT {
     const port = opts.port || 49737
     const bootstrap = opts.bootstrap || BOOTSTRAP_NODES
 
-    super({ ...opts, port, bootstrap, addNode: shouldAddNode })
+    super({ ...opts, port, bootstrap, filterNode })
 
     if (Array.isArray(global?.Pear?.config?.dht)) {
       global.Pear.config.dht.forEach(node => {
@@ -549,7 +549,7 @@ function toRange (n) {
   return typeof n === 'number' ? [n, n] : n
 }
 
-function shouldAddNode (node) {
+function filterNode (node) {
   // always skip these testnet nodes that got mixed in by accident, until they get updated
   return !(node.port === 49738 && (node.host === '134.209.28.98' || node.host === '167.99.142.185')) &&
     !(node.port === 9400 && node.host === '35.233.47.252') && !(node.host === '150.136.142.116')

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ class HyperDHT extends DHT {
     const port = opts.port || 49737
     const bootstrap = opts.bootstrap || BOOTSTRAP_NODES
 
-    super({ ...opts, port, bootstrap, shouldAddNode })
+    super({ ...opts, port, bootstrap, addNode: shouldAddNode })
 
     if (Array.isArray(global?.Pear?.config?.dht)) {
       global.Pear.config.dht.forEach(node => {

--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const Persistent = require('./lib/persistent')
 const Router = require('./lib/router')
 const Server = require('./lib/server')
 const connect = require('./lib/connect')
-const { FIREWALL, BOOTSTRAP_NODES, COMMANDS } = require('./lib/constants')
+const { FIREWALL, BOOTSTRAP_NODES, KNOWN_NODES, COMMANDS } = require('./lib/constants')
 const { hash, createKeyPair } = require('./lib/crypto')
 const { decode } = require('hypercore-id-encoding')
 const RawStreamSet = require('./lib/raw-stream-set')
@@ -24,11 +24,7 @@ class HyperDHT extends DHT {
 
     super({ ...opts, port, bootstrap, filterNode })
 
-    if (Array.isArray(global?.Pear?.config?.dht)) {
-      global.Pear.config.dht.forEach(node => {
-        this.addNode(node)
-      })
-    }
+    for (const node of KNOWN_NODES) this.addNode(node)
 
     const { router, persistent } = defaultCacheOpts(opts)
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,7 +19,7 @@ exports.BOOTSTRAP_NODES = [
   '138.68.147.8@node3.hyperdht.org:49737'
 ]
 
-exports.KNOWN_NODES = global?.Pear?.config?.dht || []
+exports.KNOWN_NODES = global.Pear?.config.dht || []
 
 exports.FIREWALL = {
   UNKNOWN: 0,

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -19,6 +19,8 @@ exports.BOOTSTRAP_NODES = [
   '138.68.147.8@node3.hyperdht.org:49737'
 ]
 
+exports.KNOWN_NODES = global?.Pear?.config?.dht || []
+
 exports.FIREWALL = {
   UNKNOWN: 0,
   OPEN: 1,

--- a/test/connections.js
+++ b/test/connections.js
@@ -789,7 +789,7 @@ test('fail to bootstrap completely', async function (t) {
   await a.destroy()
 })
 
-test('Populate DHT with available nodes from Pear.config.dht', async function (t) {
+test('Populate DHT with options.knownNodes', async function (t) {
   const a = new DHT({ bootstrap: [] })
   await a.ready()
   const knownNodes = [{ host: '127.0.0.1', port: a.address().port }]

--- a/test/connections.js
+++ b/test/connections.js
@@ -792,16 +792,9 @@ test('fail to bootstrap completely', async function (t) {
 test('Populate DHT with available nodes from Pear.config.dht', async function (t) {
   const a = new DHT({ bootstrap: [] })
   await a.ready()
+  const knownNodes = [{ host: '127.0.0.1', port: a.address().port }]
 
-  global.Pear = {
-    config: {
-      dht: [
-        { host: '127.0.0.1', port: a.address().port }
-      ]
-    }
-  }
-
-  const b = new DHT({ bootstrap: [] })
+  const b = new DHT({ knownNodes, bootstrap: [] })
   await b.ready()
 
   t.alike(b.toArray(), [{ host: '127.0.0.1', port: a.address().port }])

--- a/test/connections.js
+++ b/test/connections.js
@@ -788,3 +788,25 @@ test('fail to bootstrap completely', async function (t) {
 
   await a.destroy()
 })
+
+test('Populate DHT with available nodes from Pear.config.dht', async function (t) {
+  const a = new DHT({ bootstrap: [] })
+  await a.ready()
+
+  global.Pear = {
+    config: {
+      dht: [
+        { host: '127.0.0.1', port: a.address().port }
+      ]
+    }
+  }
+
+  const b = new DHT({ bootstrap: [] })
+  await b.ready()
+
+  t.alike(b.toArray(), [{ host: '127.0.0.1', port: a.address().port }])
+
+  a.destroy()
+  b.destroy()
+  delete global.Pear
+})


### PR DESCRIPTION
* Renamed `HyperDHT.addNode()` (very misleading name, this actually checks for skipping testnet nodes) renamed to `filterNode()`