### PR TITLE
(cleanup) consistently use SUSPENDED error in connect

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -48,7 +48,7 @@ module.exports = function connect (dht, publicKey, opts = {}) {
 
   // in case a socket is made during suspended state, destroy it immediately
   if (dht.suspended) {
-    encryptedSocket.destroy(new Error('Suspended'))
+    encryptedSocket.destroy(SUSPENDED())
     return encryptedSocket
   }
 


### PR DESCRIPTION
Currently, connect throws a SUSPENDED() error here: https://github.com/holepunchto/hyperdht/blob/c339c868be15c6096e9f7f30dd0445791f903392/lib/connect.js#L110. This PR makes it throw the same error for another case in the same function, for consistency.