### PR TITLE
Port defaults to [49737, 49737 + 5]

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,7 +18,7 @@ const { STREAM_NOT_CONNECTED } = require('./lib/errors')
 
 class HyperDHT extends DHT {
   constructor (opts = {}) {
-    const port = opts.port || 49737
+    const port = opts.port || [49737, 49737 + 5]
     const bootstrap = opts.bootstrap || BOOTSTRAP_NODES
     const nodes = opts.nodes || KNOWN_NODES
 

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "bogon": "^1.0.0",
     "compact-encoding": "^2.4.1",
     "compact-encoding-net": "^1.0.1",
-    "dht-rpc": "^6.15.1",
+    "dht-rpc": "holepunchto/dht-rpc#port-range",
     "hypercore-crypto": "^3.3.0",
     "hypercore-id-encoding": "^1.2.0",
     "noise-curve-ed": "^2.0.0",


### PR DESCRIPTION
Draft because it relies on https://github.com/holepunchto/dht-rpc/pull/92 to be released (we should bump the package.json min dependency)