### PR TITLE
Add bare tests to CI

### DIFF
--- a/.github/workflows/test-node.yml
+++ b/.github/workflows/test-node.yml
@@ -27,6 +27,8 @@ jobs:
       - run: npm install
       - run: npm test
       - run: npm run integration
+      - run: npm i -g bare
+      - run: npm run test:bare
   trigger_canary:
     if: startsWith(github.ref, 'refs/tags/') # Only run when a new package is published (detects when a new tag is pushed)
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -18,6 +18,10 @@
     "events": {
       "bare": "bare-events",
       "default": "events"
+    },
+    "child_process": {
+      "bare": "bare-node-child-process",
+      "default": "child_process"
     }
   },
   "dependencies": {
@@ -42,6 +46,7 @@
     "xache": "^1.1.0"
   },
   "devDependencies": {
+    "bare-node-child-process": "^1.0.1",
     "brittle": "^3.0.0",
     "graceful-goodbye": "^1.3.0",
     "newline-decoder": "^1.0.2",
@@ -49,6 +54,7 @@
   },
   "scripts": {
     "test": "standard && node test/all.js",
+    "test:bare": "bare test/all.js",
     "test:generate": "brittle -r test/all.js test/*.js",
     "lint": "standard",
     "integration": "brittle test/integration/*.js",


### PR DESCRIPTION
Not including the bare tests in `npm t` because that would cause the tests to run twice as long during local development. Open to including it there though, if you believe that's better.