### PR TITLE
bump `sodium-universal` to `5.0.1`

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "record-cache": "^1.1.1",
     "safety-catch": "^1.0.1",
     "signal-promise": "^1.0.3",
-    "sodium-universal": "^4.0.0",
+    "sodium-universal": "^5.0.1",
     "streamx": "^2.16.1",
     "unslab": "^1.3.0",
     "xache": "^1.1.0"


### PR DESCRIPTION
Depends on:

- https://github.com/chm-diederichs/noise-curve-ed/pull/6
- https://github.com/holepunchto/noise-handshake/pull/16
- https://github.com/holepunchto/hypercore-crypto/pull/19
- https://github.com/mafintosh/sodium-secretstream/pull/4
- https://github.com/holepunchto/hyperswarm-secret-stream/pull/46
- https://github.com/holepunchto/blind-relay/pull/7
- https://github.com/holepunchto/dht-rpc/pull/98
