### PR TITLE
Always cleanup handshake on abort

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -387,6 +387,11 @@ module.exports = class Server extends EventEmitter {
     const onabort = () => {
       if (hs.prepunching) clearTimeout(hs.prepunching)
       hs.prepunching = null
+      if (hs.rawStream.destroyed) {
+        this._clearLater(hs, id, k)
+        return
+      }
+
       hs.rawStream.on('close', () => this._clearLater(hs, id, k))
       if (hs.relayToken === null) hs.rawStream.destroy()
     }


### PR DESCRIPTION
Note: unsure if we ever reach that code with a destroyed rawStream (hard to trace all possibilities), but it definitely doesn't hurt