### PR TITLE
No relay attempt if the remote firewall is open

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -373,15 +373,15 @@ module.exports = class Server extends EventEmitter {
       return hs
     }
 
-    if (relayThrough || remotePayload.relayThrough) {
-      this._relayConnection(hs, relayThrough, remotePayload, h)
-    }
-
     if (remotePayload.firewall === FIREWALL.OPEN || direct) {
       const sock = direct ? socket : this.dht.socket
       this.dht.stats.punches.open++
       hs.onsocket(sock, clientAddress.port, clientAddress.host)
       return hs
+    }
+
+    if (relayThrough || remotePayload.relayThrough) {
+      this._relayConnection(hs, relayThrough, remotePayload, h)
     }
 
     const onabort = () => {


### PR DESCRIPTION
Since for that case we connect directly anyway, so the relay attempt is useless (and might be the cause of race conditions related to the handshake lifecycle)