### PR TITLE
Bugfix: clean up holepunch state for relayed connections that never connect

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -316,7 +316,6 @@ module.exports = class Server extends EventEmitter {
           if (remoteChanging) remoteChanging.catch(safetyCatch)
         } else {
           hs.rawStream.connect(socket, remotePayload.udx.id, port, host)
-
           hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {
             handshake: h,
             keepAlive: this.dht.connectionKeepAlive

--- a/lib/server.js
+++ b/lib/server.js
@@ -292,7 +292,9 @@ module.exports = class Server extends EventEmitter {
       // Handles the case where onsocket is never called, but the stream got setup
       // This can happen on a relayed connection which never connects directly
       // (onsocket is called there only when the direct connection is established)
-      hs.rawStream.on('close', () => this._clearLater(hs, id, k))
+      const onrawstreamclose = () => {
+        this._clearLater(hs, id, k)
+      }
 
       hs.onsocket = (socket, port, host) => {
         if (hs.rawStream === null) return // Already hole punched
@@ -309,6 +311,7 @@ module.exports = class Server extends EventEmitter {
         }
 
         hs.rawStream.removeListener('error', autoDestroy)
+        hs.rawStream.removeListener('close', onrawstreamclose)
 
         if (hs.rawStream.connected) {
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)

--- a/lib/server.js
+++ b/lib/server.js
@@ -289,6 +289,11 @@ module.exports = class Server extends EventEmitter {
 
       hs.rawStream.on('error', autoDestroy)
 
+      // Handles the case where onsocket is never called, but the stream got setup
+      // This can happen on a relayed connection which never connects directly
+      // (onsocket is called there only when the direct connection is established)
+      hs.rawStream.on('close', () => this._clearLater(hs, id, k))
+
       hs.onsocket = (socket, port, host) => {
         if (hs.rawStream === null) return // Already hole punched
 
@@ -311,6 +316,7 @@ module.exports = class Server extends EventEmitter {
           if (remoteChanging) remoteChanging.catch(safetyCatch)
         } else {
           hs.rawStream.connect(socket, remotePayload.udx.id, port, host)
+
           hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {
             handshake: h,
             keepAlive: this.dht.connectionKeepAlive

--- a/lib/server.js
+++ b/lib/server.js
@@ -295,6 +295,7 @@ module.exports = class Server extends EventEmitter {
       const onrawstreamclose = () => {
         this._clearLater(hs, id, k)
       }
+      hs.rawStream.on('close', onrawstreamclose)
 
       hs.onsocket = (socket, port, host) => {
         if (hs.rawStream === null) return // Already hole punched


### PR DESCRIPTION
This fix ensures that when the `rawStream` closes before `onsocket` was called, we always clean up the holepunching state, which is a sensible invariant. It's usually redundant, but analysis of a memory leak showed  at least one code path where it is needed:

- A relayed connection gets set up successfully
- But the 2 sides never communicate directly
=> the abort+cleanup logic never triggers (because they connected), but the happy-path cleanup of `onsocket` is never called from `firewall (...)` because they never connected directly

The leak occurred for `hs` state where:
- `hs.relayPaired === true`,  so the relayed connection got set up successfully
- `hs.rawStream` is still set, and `hs.rawStream.closed = true`, so the underlying stream got destroyed
- `hs.onsocket` is never called, because otherwise the cleanup logic would have run (and `rawStream` would have been set to null) 
- `hs.relaySocket.rawStream.closed === true`, so the relay stream also got destroyed
- `h.puncher === null`, so it never tried to holepunch


