### PR TITLE
Bugfix: clean up after failed relay attempt

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -404,7 +404,6 @@ module.exports = class Server extends EventEmitter {
       }
 
       hs.rawStream.on('close', () => this._clearLater(hs, id, k))
-
       if (hs.relayToken === null) hs.rawStream.destroy()
     }
 


### PR DESCRIPTION
I believe this fixes a memory leak of `hyperdht/Server._holepunches` entries, for the case where it attempts to relay a connection but never succeeds.

It's an extension to https://github.com/holepunchto/hyperdht/pull/221. This PR fixes an edge case, by destroying the raw stream if the relay attempt aborts without ever sending any data.

The leaked state in the heapdump is:
- `hs.relayClient._destroyed === true`, `hs.relayPaired === false`, `hs.relayToken === null`)
   => The relay attempt was started
   => No data was ever received over the relay (otherwise `hs.relayPaired` would be `true`)
   => the relay attempt was aborted (otherwise `hs.relayToken` would not be null)
- `hs.rawStream.closed === false` and `hs.rawStream.socket === null`
   => No connection got hooked up to the raw stream, but it did not get destroyed either

I believe the edge case happens when we abort the relay attempt after we have already aborted the unrelayed flow (which only cleans up the rawStream if there is no ongoing relay attempt). The fix is to check in the relay abort if we have already aborted the unrelayed flow, and if so: destroy the raw stream.

old relay abort code:
https://github.com/holepunchto/hyperdht/blob/0d1298b631126a425f8825bbef73edb7df5dfbd6/lib/server.js#L659-L665

old unrelayed abort flow
 https://github.com/holepunchto/hyperdht/blob/0d1298b631126a425f8825bbef73edb7df5dfbd6/lib/server.js#L396-L406



