### PR TITLE
Include relay stats

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,11 @@ class HyperDHT extends DHT {
       : opts.connectionKeepAlive || 5000
 
     // stats is inherited from dht-rpc so fwd the ones from there
-    this.stats = { punches: { consistent: 0, random: 0, open: 0 }, ...this.stats }
+    this.stats = {
+      punches: { consistent: 0, random: 0, open: 0 },
+      relaying: { attempts: 0, successes: 0, aborts: 0 },
+      ...this.stats
+    }
     this.rawStreams = new RawStreamSet(this)
 
     this._router = new Router(this, router)

--- a/lib/server.js
+++ b/lib/server.js
@@ -661,7 +661,7 @@ module.exports = class Server extends EventEmitter {
 
     const dht = this.dht
     function onabort () {
-      dht.stats.relaying.aborts++
+      if (!hs.relayPaired) dht.stats.relaying.aborts++
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null

--- a/lib/server.js
+++ b/lib/server.js
@@ -606,6 +606,8 @@ module.exports = class Server extends EventEmitter {
   }
 
   _relayConnection (hs, relayThrough, remotePayload, h) {
+    this.dht.stats.relaying.attempts++
+
     let isInitiator
     let publicKey
     let token
@@ -637,6 +639,7 @@ module.exports = class Server extends EventEmitter {
         }
 
         hs.relayPaired = true
+        this.dht.stats.relaying.successes++
 
         if (hs.prepunching) clearTimeout(hs.prepunching)
         hs.prepunching = null
@@ -656,7 +659,9 @@ module.exports = class Server extends EventEmitter {
         this.onconnection(hs.encryptedSocket)
       })
 
+    const dht = this.dht
     function onabort () {
+      dht.stats.relaying.aborts++
       if (hs.relayTimeout) clearRelayTimeout(hs)
       const socket = hs.relaySocket
       hs.relayToken = null


### PR DESCRIPTION
These stats only included relay connections set up by the server, not from `connect.js`. I can include those as well, but it's less clean (it requires passing the stats object through to a lot of functions, since it's not a class)

Note: there's an implicit stat of `relayingInProcess = relaying.attempts - relaying.successes - relaying.aborts` which will be interesting to graph