### PR TITLE
Add holepunching support on LAN

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -1,7 +1,7 @@
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const b4a = require('b4a')
 const relay = require('blind-relay')
-const { isReserved, isBogon } = require('bogon')
+const { isReserved, isPrivate, isBogon } = require('bogon')
 const safetyCatch = require('safety-catch')
 const unslab = require('unslab')
 const Semaphore = require('./semaphore')
@@ -228,26 +228,6 @@ async function holepunch(c, opts) {
   if (c.firewall === FIREWALL.OPEN) {
     c.passiveConnectTimeout = setTimeout(onabort, 10000)
     return
-  }
-
-  // TODO: would be better to just try local addrs in the background whilst continuing with other strategies...
-  if (c.lan && relayed && clientAddress.host === serverAddress.host) {
-    const serverAddresses = payload.addresses4.filter(onlyNonReserved)
-
-    if (serverAddresses.length > 0) {
-      const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
-      const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
-
-      const socket = c.dht.io.serverSocket
-      try {
-        await c.dht.ping(addr)
-      } catch {
-        maybeDestroyEncryptedSocket(c, HOLEPUNCH_ABORTED())
-        return
-      }
-      c.onsocket(socket, addr.port, addr.host)
-      return
-    }
   }
 
   if (!remoteHolepunchable) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -388,9 +388,21 @@ module.exports = class Server extends EventEmitter {
     }
 
     if (remotePayload.firewall === FIREWALL.OPEN || direct) {
+      let connectAddr = clientAddress
+      // When on the same LAN, the client's external address requires NAT hairpinning
+      // which most routers don't support. Use the client's LAN address instead.
+      if (!direct && clientAddress.host === serverAddress.host && !isPrivate(clientAddress.host)) {
+        const clientLanAddrs = remotePayload.addresses4.filter(onlyPrivateHosts)
+        if (clientLanAddrs.length > 0) {
+          const myAddresses = Holepuncher.localAddresses(this.dht.io.serverSocket)
+          const lanAddr = Holepuncher.matchAddress(myAddresses, clientLanAddrs)
+          if (lanAddr) connectAddr = lanAddr
+        }
+      }
+
       const sock = direct ? socket : this.dht.socket
       this.dht.stats.punches.open++
-      hs.onsocket(sock, clientAddress.port, clientAddress.host)
+      hs.onsocket(sock, connectAddr.port, connectAddr.host)
       return hs
     }
 
@@ -411,15 +423,16 @@ module.exports = class Server extends EventEmitter {
       if (hs.relayToken === null) hs.rawStream.destroy()
     }
 
-    if (!direct && clientAddress.host === serverAddress.host) {
+    if (!direct && clientAddress.host === serverAddress.host && !isPrivate(clientAddress.host)) {
       const clientAddresses = remotePayload.addresses4.filter(onlyPrivateHosts)
 
-      if (clientAddresses.length > 0 && this._shareLocalAddress) {
-        const myAddresses = await this._localAddresses()
+      if (clientAddresses.length > 0) {
+        const myAddresses = Holepuncher.localAddresses(this.dht.io.serverSocket)
         const addr = Holepuncher.matchAddress(myAddresses, clientAddresses)
 
         if (addr) {
-          hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
+          this.dht.stats.punches.open++
+          hs.onsocket(this.dht.socket, addr.port, addr.host)
           return hs
         }
       }


### PR DESCRIPTION
Currently on LAN after discovering that both peers are on LAN, the client just pings the server using a dht.ping() and waits for it to respond, however if the server is behind a firewall that ping never resolves and we throw a HOLEPUNCH_ABORTED error where we never actually holepunch.

This PR changes that and enables holepunching b/w LAN clients as well.

Info: I used AI to help me with this PR and I have written it to the best of my knowledge.