### PR TITLE
Pre-connect to `closestNodes` in parallel to `FIND_PEER` query

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -379,11 +379,7 @@ async function findAndConnect(c, opts) {
         }
 
         // Skip node already run via preConnect
-        if (
-          preConnect &&
-          closestNodes &&
-          closestNodes.find((n) => n.host === data.from.host && n.port === data.from.port)
-        ) {
+        if (preConnect && closestNodes && isClosestNode(closestNodes, data)) {
           sem.signal()
           continue
         }
@@ -877,6 +873,14 @@ function selectRelay(relayThrough) {
   if (Array.isArray(relayThrough))
     return relayThrough[Math.floor(Math.random() * relayThrough.length)]
   return relayThrough
+}
+
+function isClosestNode(closestNodes, data) {
+  for (const node of closestNodes) {
+    if (node.host === data.from.host && node.port === data.from.port) return true
+  }
+
+  return false
 }
 
 function noop() {}

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -381,6 +381,7 @@ async function findAndConnect(c, opts) {
         // Skip node already run via preConnect
         if (
           preConnect &&
+          closestNodes &&
           closestNodes.find((n) => n.host === data.from.host && n.port === data.from.port)
         ) {
           sem.signal()

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -334,30 +334,31 @@ async function connectThroughNodes(c, addresses, socket) {
 
 async function findAndConnect(c, opts) {
   let attempts = 0
-  let closestNodes = opts.relayAddresses && opts.relayAddresses.length ? opts.relayAddresses : null
+  let relayAddresses =
+    opts.relayAddresses && opts.relayAddresses.length ? opts.relayAddresses : null
 
-  if (!closestNodes) {
+  if (!relayAddresses) {
     const cachedRelayAddresses = c.dht._relayAddressesCache.get(c.id)
-    if (cachedRelayAddresses) closestNodes = cachedRelayAddresses
+    if (cachedRelayAddresses) relayAddresses = cachedRelayAddresses
   }
 
   if (c.dht._persistent) {
     // check if we know the route ourself...
     const route = c.dht._router.get(c.target)
     if (route && route.relay !== null) {
-      closestNodes = [{ host: route.relay.host, port: route.relay.port }]
+      relayAddresses = [{ host: route.relay.host, port: route.relay.port }]
     }
   }
 
   // 2 is how many parallel connect attempts we want to do, we can make this configurable
-  const preConnect = closestNodes !== null && closestNodes.length > 0
+  const preConnect = relayAddresses !== null && relayAddresses.length > 0
   const sem = new Semaphore(preConnect ? 3 : 2)
   const signal = sem.signal.bind(sem)
-  const tries = closestNodes !== null ? 2 : 1
+  const tries = relayAddresses !== null ? 2 : 1
 
   if (preConnect) {
     await sem.wait()
-    connectThroughNodes(c, closestNodes, null).then(signal, signal)
+    connectThroughNodes(c, relayAddresses, null).then(signal, signal)
   }
 
   try {
@@ -365,7 +366,7 @@ async function findAndConnect(c, opts) {
       c.query = c.dht.findPeer(c.target, {
         hash: false,
         session: c.session,
-        closestNodes,
+        nodes: relayAddresses,
         retries: 3
       })
 
@@ -379,7 +380,7 @@ async function findAndConnect(c, opts) {
         }
 
         // Skip node already run via preConnect
-        if (preConnect && closestNodes && isClosestNode(closestNodes, data)) {
+        if (preConnect && relayAddresses && isRelayAddress(relayAddresses, data)) {
           sem.signal()
           continue
         }
@@ -389,7 +390,7 @@ async function findAndConnect(c, opts) {
         connectThroughNode(c, data.from, null).then(signal, signal)
       }
 
-      closestNodes = null
+      relayAddresses = null
 
       if (attempts > 0) await sem.flush()
     }
@@ -875,8 +876,8 @@ function selectRelay(relayThrough) {
   return relayThrough
 }
 
-function isClosestNode(closestNodes, data) {
-  for (const node of closestNodes) {
+function isRelayAddress(relayAddresses, data) {
+  for (const node of relayAddresses) {
     if (node.host === data.from.host && node.port === data.from.port) return true
   }
 

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -355,7 +355,10 @@ async function findAndConnect(c, opts) {
   const tries = closestNodes !== null ? 2 : 1
   const preConnect = closestNodes !== null && closestNodes.length > 0
 
-  if (preConnect) connectThroughNodes(c, closestNodes, null).then(signal, signal)
+  if (preConnect) {
+    await sem.wait()
+    connectThroughNodes(c, closestNodes, null).then(signal, signal)
+  }
 
   try {
     for (let i = 0; i < tries && !isDone(c) && !c.connect; i++) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -327,6 +327,7 @@ async function connectThroughNodes(c, addresses, socket) {
   for (const address of addresses) {
     if (isDone(c) || c.connect) return
 
+    c.remoteRelayAddresses.push(address)
     await connectThroughNode(c, address, socket)
   }
 }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -350,10 +350,10 @@ async function findAndConnect(c, opts) {
   }
 
   // 2 is how many parallel connect attempts we want to do, we can make this configurable
-  const sem = new Semaphore(closestNodes !== null ? 3 : 2)
+  const preConnect = closestNodes !== null && closestNodes.length > 0
+  const sem = new Semaphore(preConnect ? 3 : 2)
   const signal = sem.signal.bind(sem)
   const tries = closestNodes !== null ? 2 : 1
-  const preConnect = closestNodes !== null && closestNodes.length > 0
 
   if (preConnect) {
     await sem.wait()

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -323,6 +323,14 @@ async function holepunch(c, opts) {
   }
 }
 
+async function connectThroughNodes(c, addresses, socket) {
+  for (const address of addresses) {
+    if (isDone(c) || c.connect) return
+
+    await connectThroughNode(c, address, socket)
+  }
+}
+
 async function findAndConnect(c, opts) {
   let attempts = 0
   let closestNodes = opts.relayAddresses && opts.relayAddresses.length ? opts.relayAddresses : null
@@ -341,9 +349,12 @@ async function findAndConnect(c, opts) {
   }
 
   // 2 is how many parallel connect attempts we want to do, we can make this configurable
-  const sem = new Semaphore(2)
+  const sem = new Semaphore(closestNodes !== null ? 3 : 2)
   const signal = sem.signal.bind(sem)
   const tries = closestNodes !== null ? 2 : 1
+  const preConnect = closestNodes !== null && closestNodes.length > 0
+
+  if (preConnect) connectThroughNodes(c, closestNodes, null).then(signal, signal)
 
   try {
     for (let i = 0; i < tries && !isDone(c) && !c.connect; i++) {
@@ -351,8 +362,7 @@ async function findAndConnect(c, opts) {
         hash: false,
         session: c.session,
         closestNodes,
-        onlyClosestNodes: closestNodes !== null,
-        retries: closestNodes ? 1 : 3
+        retries: 3
       })
 
       for await (const data of c.query) {
@@ -362,6 +372,15 @@ async function findAndConnect(c, opts) {
         if (c.connect) {
           sem.signal()
           break
+        }
+
+        // Skip node already run via preConnect
+        if (
+          preConnect &&
+          closestNodes.find((n) => n.host === data.from.host && n.port === data.from.port)
+        ) {
+          sem.signal()
+          continue
         }
 
         c.remoteRelayAddresses.push(data.from)

--- a/test/pool.js
+++ b/test/pool.js
@@ -46,12 +46,16 @@ test('connection pool, server side', async function (t) {
 
   const open = t.test('open')
   open.plan(2)
+  let atLeastOneOpen = false
 
   {
     const socket = b.connect(server.publicKey)
     socket
       .on('open', () => {
+        if (atLeastOneOpen) return
+
         open.pass('1st stream opened')
+        atLeastOneOpen = true
       })
       .on('error', () => {
         open.pass('1st stream errored')
@@ -62,7 +66,10 @@ test('connection pool, server side', async function (t) {
     const socket = b.connect(server.publicKey)
     socket
       .on('open', () => {
+        if (atLeastOneOpen) return
+
         open.pass('2nd stream opened')
+        atLeastOneOpen = true
       })
       .on('error', () => {
         open.pass('2nd stream errored')
@@ -71,6 +78,7 @@ test('connection pool, server side', async function (t) {
   }
 
   await open
+  t.ok(atLeastOneOpen, 'verify one client opened')
 
   await server.close()
 })


### PR DESCRIPTION
Builds on the `nodes-in-key` PR #237 to use `closestNodes` from either the key, cache or passed option and attempts connecting through the `closestNodes` in parallel to querying the DHT for more fresh nodes. This should skip the query when the cached node is still good and will speed up connections especially on slower devices where querying the DHT is more expensive because of latency or dropped packets.

The `closestNodes` are still passed to the `FIND_PEER` to speed up the query in the case that the closestNodes have updated their record of the `target`. The normal 2 tries is kept.