### PR TITLE
Fix relay abort propagation

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -726,7 +726,7 @@ function maybeDestroyEncryptedSocket(c, err) {
 
 async function abort(c, { peerAddress, relayAddress }, err) {
   try {
-    await updateHolepunch(peerAddress, relayAddress, {
+    await updateHolepunch(c, peerAddress, relayAddress, {
       error: ERROR.ABORTED,
       firewall: FIREWALL.UNKNOWN,
       round: c.round++,

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -128,19 +128,7 @@ test('relay connections through node, server side, client abort notifies remote'
 
   const lc = t.test('socket lifecycle')
   lc.plan(5)
-
-  let holepunchCalls = 0
-  let holepunchCallsAtAbort = -1
-  const peerHolepunch = c._router.peerHolepunch.bind(c._router)
-
-  c._router.peerHolepunch = async function (...args) {
-    holepunchCalls++
-    return peerHolepunch(...args)
-  }
-
-  t.teardown(() => {
-    c._router.peerHolepunch = peerHolepunch
-  })
+  let clientAbortedUpgrade = false
 
   const relay = new RelayServer({
     createStream(opts) {
@@ -177,11 +165,13 @@ test('relay connections through node, server side, client abort notifies remote'
 
   await bServer.listen()
 
+  const remoteAbort = waitFor(() => bServer._holepunches.some((hs) => hs && hs.aborted))
+
   const bSocket = c.connect(bServer.publicKey, {
     fastOpen: false,
     localConnection: false,
     holepunch() {
-      holepunchCallsAtAbort = holepunchCalls
+      clientAbortedUpgrade = true
       return false
     }
   })
@@ -196,18 +186,27 @@ test('relay connections through node, server side, client abort notifies remote'
     .end('hello world')
 
   await lc
-  await new Promise((resolve) => setTimeout(resolve, 50))
+  await remoteAbort
 
-  t.ok(holepunchCallsAtAbort >= 0, 'client reached the holepunch decision point')
-  t.ok(
-    holepunchCalls > holepunchCallsAtAbort,
-    'client sends a follow-up abort message after declining the direct upgrade'
-  )
+  t.ok(clientAbortedUpgrade, 'client reached the holepunch decision point')
+  t.pass('remote records the client abort')
 
   await a.destroy()
   await b.destroy()
   await c.destroy()
 })
+
+async function waitFor(fn, timeout = 2000) {
+  const started = Date.now()
+
+  while (!fn()) {
+    if (Date.now() - started > timeout) {
+      throw new Error('Timed out waiting for test condition')
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
 
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -119,6 +119,96 @@ test('relay connections through node, client side, client aborts hole punch', as
   await c.destroy()
 })
 
+test('relay connections through node, server side, client abort notifies remote', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const c = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const lc = t.test('socket lifecycle')
+  lc.plan(5)
+
+  let holepunchCalls = 0
+  let holepunchCallsAtAbort = -1
+  const peerHolepunch = c._router.peerHolepunch.bind(c._router)
+
+  c._router.peerHolepunch = async function (...args) {
+    holepunchCalls++
+    return peerHolepunch(...args)
+  }
+
+  t.teardown(() => {
+    c._router.peerHolepunch = peerHolepunch
+  })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return a.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const aServer = a.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await aServer.listen()
+
+  const bServer = b.createServer(
+    {
+      relayThrough: aServer.publicKey,
+      shareLocalAddress: false
+    },
+    function (socket) {
+      lc.pass('server socket opened')
+      socket
+        .on('data', (data) => {
+          lc.alike(data, Buffer.from('hello world'))
+        })
+        .on('close', () => {
+          lc.pass('server socket closed')
+        })
+        .end()
+    }
+  )
+
+  await bServer.listen()
+
+  const bSocket = c.connect(bServer.publicKey, {
+    fastOpen: false,
+    localConnection: false,
+    holepunch() {
+      holepunchCallsAtAbort = holepunchCalls
+      return false
+    }
+  })
+
+  bSocket
+    .on('open', () => {
+      lc.pass('client socket opened')
+    })
+    .on('close', () => {
+      lc.pass('client socket closed')
+    })
+    .end('hello world')
+
+  await lc
+  await new Promise((resolve) => setTimeout(resolve, 50))
+
+  t.ok(holepunchCallsAtAbort >= 0, 'client reached the holepunch decision point')
+  t.ok(
+    holepunchCalls > holepunchCallsAtAbort,
+    'client sends a follow-up abort message after declining the direct upgrade'
+  )
+
+  await a.destroy()
+  await b.destroy()
+  await c.destroy()
+})
+
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -127,10 +127,15 @@ test('relay connections through node, server side, client abort notifies remote'
   const c = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(5)
+  lc.plan(6)
+  let sawRelayStream = false
 
   const relay = new RelayServer({
     createStream(opts) {
+      if (!sawRelayStream) {
+        sawRelayStream = true
+        lc.pass('sanity check: using the relay')
+      }
       return a.createRawStream({ ...opts, framed: true })
     }
   })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -128,7 +128,6 @@ test('relay connections through node, server side, client abort notifies remote'
 
   const lc = t.test('socket lifecycle')
   lc.plan(5)
-  let clientAbortedUpgrade = false
 
   const relay = new RelayServer({
     createStream(opts) {
@@ -171,7 +170,6 @@ test('relay connections through node, server side, client abort notifies remote'
     fastOpen: false,
     localConnection: false,
     holepunch() {
-      clientAbortedUpgrade = true
       return false
     }
   })
@@ -188,7 +186,6 @@ test('relay connections through node, server side, client abort notifies remote'
   await lc
   await remoteAbort
 
-  t.ok(clientAbortedUpgrade, 'client reached the holepunch decision point')
   t.pass('remote records the client abort')
 
   await a.destroy()


### PR DESCRIPTION
`updateHolepunch` was previously called with wrong arguments, and bad test coverage did allow this behaviour previously

Tests where co-written with AI