### PR TITLE
Test/relay direct upgrade coverage

### DIFF
--- a/test/relaying.js
+++ b/test/relaying.js
@@ -437,8 +437,10 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const c = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
+  // Capture raw-stream transitions so we can prove the socket upgrades in place.
   instrumentRawStreams(t, b)
   instrumentRawStreams(t, c)
+  // Give the relay path a short head start so the upgrade ordering is deterministic.
   delayPunching(t, 500)
 
   const relay = new RelayServer({
@@ -491,10 +493,12 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
   t.is(clientSocket.rawStream._transitions[0].type, 'connect')
   t.is(serverSocket.rawStream._transitions[0].type, 'connect')
 
+  // The relayed connection should already be usable before the direct path wins.
   const beforeUpgrade = once(clientSocket, 'data')
   clientSocket.write(Buffer.from('before upgrade'))
   t.alike((await beforeUpgrade)[0], Buffer.from('before upgrade'), 'relay path carries data')
 
+  // changeRemote is the signal that the same raw stream switched transport.
   await waitForUpgrade(clientSocket.rawStream)
   await waitForUpgrade(serverSocket.rawStream)
 
@@ -603,6 +607,7 @@ function instrumentRawStreams(t, dht) {
     const stream = createRawStream(...args)
     stream._transitions = []
 
+    // Record the initial relay connect and the later direct changeRemote.
     const connect = stream.connect.bind(stream)
     stream.connect = function (socket, id, port, host) {
       stream._transitions.push({ type: 'connect', host, port })
@@ -627,6 +632,7 @@ function delayPunching(t, ms) {
   const punch = Holepuncher.prototype._punch
 
   Holepuncher.prototype._punch = async function () {
+    // Bias the race without changing the real upgrade logic.
     await new Promise((resolve) => setTimeout(resolve, ms))
     return punch.call(this)
   }
@@ -639,6 +645,7 @@ function delayPunching(t, ms) {
 async function waitForUpgrade(stream) {
   const started = Date.now()
 
+  // Poll until the raw stream reports its remote endpoint changed.
   while (!hasUpgrade(stream)) {
     if (Date.now() - started > 5000) {
       throw new Error('Timed out waiting for relay-to-direct upgrade')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -437,11 +437,7 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
   const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  // Capture raw-stream transitions so we can prove the socket upgrades in place.
-  instrumentRawStreams(t, serverNode)
-  instrumentRawStreams(t, clientNode)
-  // Bias the race so relay wins first for these nodes only; upgrade assertions below are still condition-based.
-  delayPunching(t, 500, [serverNode, clientNode])
+  const resumePunching = pausePunching(t, [serverNode, clientNode])
 
   const relayServer = new RelayServer({
     createStream(opts) {
@@ -458,7 +454,6 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
 
   await relayTransportServer.listen()
 
-  let serverSocket = null
   let resolveServerSocket = null
   const serverSocketOpened = new Promise((resolve) => {
     resolveServerSocket = resolve
@@ -470,7 +465,6 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
       shareLocalAddress: false
     },
     function (socket) {
-      serverSocket = socket
       resolveServerSocket(socket)
 
       socket.on('data', (data) => socket.write(data))
@@ -485,37 +479,39 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
     localConnection: false
   })
 
-  await once(clientSocket, 'open')
-  await serverSocketOpened
+  const [serverSocket] = await Promise.all([serverSocketOpened, once(clientSocket, 'open')])
 
-  t.is(clientSocket.rawStream._transitions.length, 1, 'client starts on the relayed stream')
-  t.is(serverSocket.rawStream._transitions.length, 1, 'server starts on the relayed stream')
-  t.is(clientSocket.rawStream._transitions[0].type, 'connect')
-  t.is(serverSocket.rawStream._transitions[0].type, 'connect')
+  t.not(
+    serverSocket.rawStream.remotePort,
+    clientSocket.rawStream.localPort,
+    'server starts on the relayed stream'
+  )
+  t.not(
+    clientSocket.rawStream.remotePort,
+    serverSocket.rawStream.localPort,
+    'client starts on the relayed stream'
+  )
 
   // The relayed connection should already be usable before the direct path wins.
   const beforeUpgrade = once(clientSocket, 'data')
   clientSocket.write(Buffer.from('before upgrade'))
   t.alike((await beforeUpgrade)[0], Buffer.from('before upgrade'), 'relay path carries data')
 
-  // changeRemote is the signal that the same raw stream switched transport.
-  await waitForUpgrade(clientSocket.rawStream)
-  await waitForUpgrade(serverSocket.rawStream)
+  const clientUpgraded = once(clientSocket.rawStream, 'remote-changed')
+  const serverUpgraded = once(serverSocket.rawStream, 'remote-changed')
 
-  const clientTransitions = clientSocket.rawStream._transitions
-  const serverTransitions = serverSocket.rawStream._transitions
+  resumePunching()
+  await Promise.all([clientUpgraded, serverUpgraded])
 
-  t.is(clientTransitions[1].type, 'changeRemote')
-  t.is(serverTransitions[1].type, 'changeRemote')
-  t.ok(
-    clientTransitions[0].host !== clientTransitions[1].host ||
-      clientTransitions[0].port !== clientTransitions[1].port,
-    'client switches away from the relay address'
+  t.is(
+    serverSocket.rawStream.remotePort,
+    clientSocket.rawStream.localPort,
+    'server switches to the client address'
   )
-  t.ok(
-    serverTransitions[0].host !== serverTransitions[1].host ||
-      serverTransitions[0].port !== serverTransitions[1].port,
-    'server switches away from the relay address'
+  t.is(
+    clientSocket.rawStream.remotePort,
+    serverSocket.rawStream.localPort,
+    'client switches to the server address'
   )
 
   const afterUpgrade = once(clientSocket, 'data')
@@ -600,62 +596,24 @@ test.skip('relay several connections through node with pool', async function (t)
   await c.destroy()
 })
 
-function instrumentRawStreams(t, dht) {
-  const createRawStream = dht.createRawStream.bind(dht)
-
-  dht.createRawStream = function (...args) {
-    const stream = createRawStream(...args)
-    stream._transitions = []
-
-    // Record the initial relay connect and the later direct changeRemote.
-    const connect = stream.connect.bind(stream)
-    stream.connect = function (socket, id, port, host) {
-      stream._transitions.push({ type: 'connect', host, port })
-      return connect(socket, id, port, host)
-    }
-
-    const changeRemote = stream.changeRemote.bind(stream)
-    stream.changeRemote = function (socket, id, port, host) {
-      stream._transitions.push({ type: 'changeRemote', host, port })
-      return changeRemote(socket, id, port, host)
-    }
-
-    return stream
-  }
-
-  t.teardown(() => {
-    dht.createRawStream = createRawStream
-  })
-}
-
-function delayPunching(t, ms, delayedNodes) {
+function pausePunching(t, pausedNodes) {
   const punch = Holepuncher.prototype._punch
+  let resume = null
+  const punchingResumed = new Promise((resolve) => {
+    resume = resolve
+  })
 
   Holepuncher.prototype._punch = async function () {
-    // Only delay the punchers created by this test.
-    if (delayedNodes.includes(this.dht)) {
-      // Bias the race without changing the real upgrade logic.
-      await new Promise((resolve) => setTimeout(resolve, ms))
-    }
+    if (pausedNodes.includes(this.dht)) await punchingResumed
     return punch.call(this)
   }
 
   t.teardown(() => {
+    resume()
     Holepuncher.prototype._punch = punch
   })
-}
 
-async function waitForUpgrade(stream) {
-  const started = Date.now()
-
-  // Poll until the raw stream reports its remote endpoint changed.
-  while (!stream._transitions.some((transition) => transition.type === 'changeRemote')) {
-    if (Date.now() - started > 5000) {
-      throw new Error('Timed out waiting for relay-to-direct upgrade')
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 20))
-  }
+  return resume
 }
 
 test.skip('server does not support connection relaying', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -433,30 +433,30 @@ test('relay connections through node, client and server side', async function (t
 test('relay connection upgrades to direct connection', { timeout: 30000 }, async function (t) {
   const { bootstrap } = await swarm(t)
 
-  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
-  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
-  const c = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const relayNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   // Capture raw-stream transitions so we can prove the socket upgrades in place.
-  instrumentRawStreams(t, b)
-  instrumentRawStreams(t, c)
-  // Give the relay path a short head start so the upgrade ordering is deterministic.
+  instrumentRawStreams(t, serverNode)
+  instrumentRawStreams(t, clientNode)
+  // Bias the race so relay wins first; upgrade assertions below are still condition-based.
   delayPunching(t, 500)
 
-  const relay = new RelayServer({
+  const relayServer = new RelayServer({
     createStream(opts) {
-      return a.createRawStream({ ...opts, framed: true })
+      return relayNode.createRawStream({ ...opts, framed: true })
     }
   })
 
-  t.teardown(() => relay.close())
+  t.teardown(() => relayServer.close())
 
-  const aServer = a.createServer(function (socket) {
-    const session = relay.accept(socket, { id: socket.remotePublicKey })
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relayServer.accept(socket, { id: socket.remotePublicKey })
     session.on('error', (err) => t.comment(err.message))
   })
 
-  await aServer.listen()
+  await relayTransportServer.listen()
 
   let serverSocket = null
   let resolveServerSocket = null
@@ -464,9 +464,9 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
     resolveServerSocket = resolve
   })
 
-  const bServer = b.createServer(
+  const appServer = serverNode.createServer(
     {
-      relayThrough: aServer.publicKey,
+      relayThrough: relayTransportServer.publicKey,
       shareLocalAddress: false
     },
     function (socket) {
@@ -478,9 +478,9 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
     }
   )
 
-  await bServer.listen()
+  await appServer.listen()
 
-  const clientSocket = c.connect(bServer.publicKey, {
+  const clientSocket = clientNode.connect(appServer.publicKey, {
     fastOpen: false,
     localConnection: false
   })
@@ -525,9 +525,9 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
   await endAndCloseSocket(clientSocket)
   if (!serverSocket.destroyed) await once(serverSocket, 'close')
 
-  await a.destroy()
-  await b.destroy()
-  await c.destroy()
+  await relayNode.destroy()
+  await serverNode.destroy()
+  await clientNode.destroy()
 })
 
 test.skip('relay several connections through node with pool', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -440,8 +440,8 @@ test('relay connection upgrades to direct connection', { timeout: 30000 }, async
   // Capture raw-stream transitions so we can prove the socket upgrades in place.
   instrumentRawStreams(t, serverNode)
   instrumentRawStreams(t, clientNode)
-  // Bias the race so relay wins first; upgrade assertions below are still condition-based.
-  delayPunching(t, 500)
+  // Bias the race so relay wins first for these nodes only; upgrade assertions below are still condition-based.
+  delayPunching(t, 500, [serverNode, clientNode])
 
   const relayServer = new RelayServer({
     createStream(opts) {
@@ -628,12 +628,15 @@ function instrumentRawStreams(t, dht) {
   })
 }
 
-function delayPunching(t, ms) {
+function delayPunching(t, ms, delayedNodes) {
   const punch = Holepuncher.prototype._punch
 
   Holepuncher.prototype._punch = async function () {
-    // Bias the race without changing the real upgrade logic.
-    await new Promise((resolve) => setTimeout(resolve, ms))
+    // Only delay the punchers created by this test.
+    if (delayedNodes.includes(this.dht)) {
+      // Bias the race without changing the real upgrade logic.
+      await new Promise((resolve) => setTimeout(resolve, ms))
+    }
     return punch.call(this)
   }
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1,6 +1,8 @@
 const test = require('brittle')
+const { once } = require('events')
 const RelayServer = require('blind-relay').Server
-const { swarm, createDHT } = require('./helpers')
+const Holepuncher = require('../lib/holepuncher')
+const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 
 test('relay connections through node, client side', async function (t) {
   const { bootstrap } = await swarm(t)
@@ -428,6 +430,102 @@ test('relay connections through node, client and server side', async function (t
   await a.destroy()
 })
 
+test('relay connection upgrades to direct connection', { timeout: 30000 }, async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const c = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  instrumentRawStreams(t, b)
+  instrumentRawStreams(t, c)
+  delayPunching(t, 500)
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return a.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const aServer = a.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await aServer.listen()
+
+  let serverSocket = null
+  let resolveServerSocket = null
+  const serverSocketOpened = new Promise((resolve) => {
+    resolveServerSocket = resolve
+  })
+
+  const bServer = b.createServer(
+    {
+      relayThrough: aServer.publicKey,
+      shareLocalAddress: false
+    },
+    function (socket) {
+      serverSocket = socket
+      resolveServerSocket(socket)
+
+      socket.on('data', (data) => socket.write(data))
+      socket.on('end', () => socket.end())
+    }
+  )
+
+  await bServer.listen()
+
+  const clientSocket = c.connect(bServer.publicKey, {
+    fastOpen: false,
+    localConnection: false
+  })
+
+  await once(clientSocket, 'open')
+  await serverSocketOpened
+
+  t.is(clientSocket.rawStream._transitions.length, 1, 'client starts on the relayed stream')
+  t.is(serverSocket.rawStream._transitions.length, 1, 'server starts on the relayed stream')
+  t.is(clientSocket.rawStream._transitions[0].type, 'connect')
+  t.is(serverSocket.rawStream._transitions[0].type, 'connect')
+
+  const beforeUpgrade = once(clientSocket, 'data')
+  clientSocket.write(Buffer.from('before upgrade'))
+  t.alike((await beforeUpgrade)[0], Buffer.from('before upgrade'), 'relay path carries data')
+
+  await waitForUpgrade(clientSocket.rawStream)
+  await waitForUpgrade(serverSocket.rawStream)
+
+  const clientTransitions = clientSocket.rawStream._transitions
+  const serverTransitions = serverSocket.rawStream._transitions
+
+  t.is(clientTransitions[1].type, 'changeRemote')
+  t.is(serverTransitions[1].type, 'changeRemote')
+  t.ok(
+    clientTransitions[0].host !== clientTransitions[1].host ||
+      clientTransitions[0].port !== clientTransitions[1].port,
+    'client switches away from the relay address'
+  )
+  t.ok(
+    serverTransitions[0].host !== serverTransitions[1].host ||
+      serverTransitions[0].port !== serverTransitions[1].port,
+    'server switches away from the relay address'
+  )
+
+  const afterUpgrade = once(clientSocket, 'data')
+  clientSocket.write(Buffer.from('after upgrade'))
+  t.alike((await afterUpgrade)[0], Buffer.from('after upgrade'), 'direct path carries data')
+
+  await endAndCloseSocket(clientSocket)
+  if (!serverSocket.destroyed) await once(serverSocket, 'close')
+
+  await a.destroy()
+  await b.destroy()
+  await c.destroy()
+})
+
 test.skip('relay several connections through node with pool', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -497,6 +595,62 @@ test.skip('relay several connections through node with pool', async function (t)
   await b.destroy()
   await c.destroy()
 })
+
+function instrumentRawStreams(t, dht) {
+  const createRawStream = dht.createRawStream.bind(dht)
+
+  dht.createRawStream = function (...args) {
+    const stream = createRawStream(...args)
+    stream._transitions = []
+
+    const connect = stream.connect.bind(stream)
+    stream.connect = function (socket, id, port, host) {
+      stream._transitions.push({ type: 'connect', host, port })
+      return connect(socket, id, port, host)
+    }
+
+    const changeRemote = stream.changeRemote.bind(stream)
+    stream.changeRemote = function (socket, id, port, host) {
+      stream._transitions.push({ type: 'changeRemote', host, port })
+      return changeRemote(socket, id, port, host)
+    }
+
+    return stream
+  }
+
+  t.teardown(() => {
+    dht.createRawStream = createRawStream
+  })
+}
+
+function delayPunching(t, ms) {
+  const punch = Holepuncher.prototype._punch
+
+  Holepuncher.prototype._punch = async function () {
+    await new Promise((resolve) => setTimeout(resolve, ms))
+    return punch.call(this)
+  }
+
+  t.teardown(() => {
+    Holepuncher.prototype._punch = punch
+  })
+}
+
+async function waitForUpgrade(stream) {
+  const started = Date.now()
+
+  while (!hasUpgrade(stream)) {
+    if (Date.now() - started > 5000) {
+      throw new Error('Timed out waiting for relay-to-direct upgrade')
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+function hasUpgrade(stream) {
+  return stream._transitions.some((transition) => transition.type === 'changeRemote')
+}
 
 test.skip('server does not support connection relaying', async function (t) {
   const { bootstrap } = await swarm(t)

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -646,17 +646,13 @@ async function waitForUpgrade(stream) {
   const started = Date.now()
 
   // Poll until the raw stream reports its remote endpoint changed.
-  while (!hasUpgrade(stream)) {
+  while (!stream._transitions.some((transition) => transition.type === 'changeRemote')) {
     if (Date.now() - started > 5000) {
       throw new Error('Timed out waiting for relay-to-direct upgrade')
     }
 
     await new Promise((resolve) => setTimeout(resolve, 20))
   }
-}
-
-function hasUpgrade(stream) {
-  return stream._transitions.some((transition) => transition.type === 'changeRemote')
 }
 
 test.skip('server does not support connection relaying', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -430,10 +430,10 @@ test('relay connections through node, client and server side', async function (t
   await a.destroy()
 })
 
-test('relay connection upgrades to direct connection', { timeout: 30000 }, async function (t) {
+test('relay connection upgrades to direct connection', async function (t) {
   const { bootstrap } = await swarm(t)
 
-  const relayNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const relayNode = createDHT({ bootstrap })
   const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 


### PR DESCRIPTION
Adds missing test coverage for the upgrade path: 

that the relayed connection is first -> and then later upgrades to direct

and that this happens *in place*  on the same raw stream

PR co-written with AI