### PR TITLE
Use safety-catch in cleanup paths

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -766,7 +766,9 @@ async function abort(c, { peerAddress, relayAddress }, err) {
       token: null,
       remoteToken: null
     })
-  } catch {}
+  } catch (err) {
+    safetyCatch(err)
+  }
 
   destroyPuncher(c)
   maybeDestroyEncryptedSocket(c, err)

--- a/lib/server.js
+++ b/lib/server.js
@@ -117,7 +117,9 @@ module.exports = class Server extends EventEmitter {
 
     try {
       await this._listening
-    } catch {}
+    } catch (err) {
+      safetyCatch(err)
+    }
 
     this._gc()
     this._clearAll()


### PR DESCRIPTION
As as a consequence of #248 I introduce 2 places where we should do safetyCatch instead of swallowing all error in case there are errors like TypeError that should not be caught 

Waiting for #248 to be reviewed so we can make CI pass