### PR TITLE
Close relay sockets after direct upgrade

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -483,6 +483,9 @@ async function connectThroughNode(c, address, socket) {
     if (c.rawStream === null) return // Already hole punched
 
     if (c.rawStream.connected) {
+      // Once this fires, changeRemote has moved the raw stream onto the direct path.
+      c.rawStream.once('remote-changed', () => closeRelayConnection(c))
+
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
 
       if (remoteChanging) remoteChanging.catch(safetyCatch)
@@ -806,21 +809,19 @@ function relayConnection(c, relayThrough, payload, hs) {
 
     c.relayPaired = true
 
-    const { remotePort, remoteHost, socket } = c.relaySocket.rawStream
+    // Keep a stable reference since c.relaySocket is cleared after direct upgrade.
+    const relaySocket = c.relaySocket
+    const { remotePort, remoteHost, socket } = relaySocket.rawStream
 
     c.rawStream
-      .on('close', () => c.relaySocket.destroy())
+      .on('close', () => relaySocket.destroy())
       .connect(socket, remoteId, remotePort, remoteHost)
 
     c.encryptedSocket.start(c.rawStream, { handshake: hs })
   }
 
   function onabort(err) {
-    if (c.relayTimeout) clearRelayTimeout(c)
-    const socket = c.relaySocket
-    c.relayToken = null
-    c.relaySocket = null
-    if (socket) socket.destroy()
+    destroyRelayConnection(c)
     maybeDestroyEncryptedSocket(c, err || RELAY_ABORTED())
   }
 }
@@ -833,6 +834,30 @@ function clearPassiveConnectTimeout(c) {
 function clearRelayTimeout(c) {
   clearTimeout(c.relayTimeout)
   c.relayTimeout = null
+}
+
+function destroyRelayConnection(c) {
+  const socket = resetRelayConnection(c)
+
+  if (socket) socket.destroy()
+}
+
+function closeRelayConnection(c) {
+  const socket = resetRelayConnection(c)
+
+  if (socket) socket.end()
+}
+
+function resetRelayConnection(c) {
+  if (c.relayTimeout) clearRelayTimeout(c)
+
+  const socket = c.relaySocket
+  // Drop relay references so the app connection no longer keeps relay state alive.
+  c.relayToken = null
+  c.relaySocket = null
+  c.relayClient = null
+
+  return socket
 }
 
 function destroyPuncher(c) {

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -9,6 +9,11 @@ const NoiseWrap = require('./noise-wrap')
 const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
 const Sleeper = require('./sleeper')
+const {
+  clearRelayTimeout,
+  closeRelayConnection,
+  destroyRelayConnection
+} = require('./relay-connection')
 const { FIREWALL, ERROR } = require('./constants')
 const { unslabbedHash } = require('./crypto')
 const {
@@ -809,12 +814,10 @@ function relayConnection(c, relayThrough, payload, hs) {
 
     c.relayPaired = true
 
-    // Keep a stable reference since c.relaySocket is cleared after direct upgrade.
-    const relaySocket = c.relaySocket
-    const { remotePort, remoteHost, socket } = relaySocket.rawStream
+    const { remotePort, remoteHost, socket } = c.relaySocket.rawStream
 
     c.rawStream
-      .on('close', () => relaySocket.destroy())
+      .on('close', () => destroyRelayConnection(c))
       .connect(socket, remoteId, remotePort, remoteHost)
 
     c.encryptedSocket.start(c.rawStream, { handshake: hs })
@@ -829,35 +832,6 @@ function relayConnection(c, relayThrough, payload, hs) {
 function clearPassiveConnectTimeout(c) {
   clearTimeout(c.passiveConnectTimeout)
   c.passiveConnectTimeout = null
-}
-
-function clearRelayTimeout(c) {
-  clearTimeout(c.relayTimeout)
-  c.relayTimeout = null
-}
-
-function destroyRelayConnection(c) {
-  const socket = resetRelayConnection(c)
-
-  if (socket) socket.destroy()
-}
-
-function closeRelayConnection(c) {
-  const socket = resetRelayConnection(c)
-
-  if (socket) socket.end()
-}
-
-function resetRelayConnection(c) {
-  if (c.relayTimeout) clearRelayTimeout(c)
-
-  const socket = c.relaySocket
-  // Drop relay references so the app connection no longer keeps relay state alive.
-  c.relayToken = null
-  c.relaySocket = null
-  c.relayClient = null
-
-  return socket
 }
 
 function destroyPuncher(c) {

--- a/lib/relay-connection.js
+++ b/lib/relay-connection.js
@@ -1,0 +1,32 @@
+exports.clearRelayTimeout = clearRelayTimeout
+exports.closeRelayConnection = closeRelayConnection
+exports.destroyRelayConnection = destroyRelayConnection
+
+function clearRelayTimeout(connectionOrHandshake) {
+  clearTimeout(connectionOrHandshake.relayTimeout)
+  connectionOrHandshake.relayTimeout = null
+}
+
+function closeRelayConnection(connectionOrHandshake) {
+  const socket = resetRelayConnection(connectionOrHandshake)
+
+  if (socket) socket.end()
+}
+
+function destroyRelayConnection(connectionOrHandshake) {
+  const socket = resetRelayConnection(connectionOrHandshake)
+
+  if (socket) socket.destroy()
+}
+
+function resetRelayConnection(connectionOrHandshake) {
+  if (connectionOrHandshake.relayTimeout) clearRelayTimeout(connectionOrHandshake)
+
+  const socket = connectionOrHandshake.relaySocket
+  // Drop relay references so the app connection no longer keeps relay state alive.
+  connectionOrHandshake.relayToken = null
+  connectionOrHandshake.relaySocket = null
+  connectionOrHandshake.relayClient = null
+
+  return socket
+}

--- a/lib/server.js
+++ b/lib/server.js
@@ -9,6 +9,11 @@ const { FIREWALL, ERROR } = require('./constants')
 const { unslabbedHash } = require('./crypto')
 const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
+const {
+  clearRelayTimeout,
+  closeRelayConnection,
+  destroyRelayConnection
+} = require('./relay-connection')
 const { isPrivate } = require('bogon')
 const { ALREADY_LISTENING, NODE_DESTROYED, KEYPAIR_ALREADY_USED } = require('./errors')
 
@@ -668,12 +673,10 @@ module.exports = class Server extends EventEmitter {
         if (hs.prepunching) clearTimeout(hs.prepunching)
         hs.prepunching = null
 
-        // Keep a stable reference since hs.relaySocket is cleared after direct upgrade.
-        const relaySocket = hs.relaySocket
-        const { remotePort, remoteHost, socket } = relaySocket.rawStream
+        const { remotePort, remoteHost, socket } = hs.relaySocket.rawStream
 
         hs.rawStream
-          .on('close', () => relaySocket.destroy())
+          .on('close', () => destroyRelayConnection(hs))
           .connect(socket, remoteId, remotePort, remoteHost)
 
         hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, { handshake: h })
@@ -688,35 +691,6 @@ module.exports = class Server extends EventEmitter {
       if (hs.aborted && hs.rawStream) hs.rawStream.destroy()
     }
   }
-}
-
-function clearRelayTimeout(hs) {
-  clearTimeout(hs.relayTimeout)
-  hs.relayTimeout = null
-}
-
-function destroyRelayConnection(hs) {
-  const socket = resetRelayConnection(hs)
-
-  if (socket) socket.destroy()
-}
-
-function closeRelayConnection(hs) {
-  const socket = resetRelayConnection(hs)
-
-  if (socket) socket.end()
-}
-
-function resetRelayConnection(hs) {
-  if (hs.relayTimeout) clearRelayTimeout(hs)
-
-  const socket = hs.relaySocket
-  // Drop relay references so the app connection no longer keeps relay state alive.
-  hs.relayToken = null
-  hs.relaySocket = null
-  hs.relayClient = null
-
-  return socket
 }
 
 function isConsistent(fw) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -324,6 +324,9 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('close', onrawstreamclose)
 
         if (hs.rawStream.connected) {
+          // Once this fires, changeRemote has moved the raw stream onto the direct path.
+          hs.rawStream.once('remote-changed', () => closeRelayConnection(hs))
+
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
 
           if (remoteChanging) remoteChanging.catch(safetyCatch)
@@ -665,10 +668,12 @@ module.exports = class Server extends EventEmitter {
         if (hs.prepunching) clearTimeout(hs.prepunching)
         hs.prepunching = null
 
-        const { remotePort, remoteHost, socket } = hs.relaySocket.rawStream
+        // Keep a stable reference since hs.relaySocket is cleared after direct upgrade.
+        const relaySocket = hs.relaySocket
+        const { remotePort, remoteHost, socket } = relaySocket.rawStream
 
         hs.rawStream
-          .on('close', () => hs.relaySocket.destroy())
+          .on('close', () => relaySocket.destroy())
           .connect(socket, remoteId, remotePort, remoteHost)
 
         hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, { handshake: h })
@@ -679,11 +684,7 @@ module.exports = class Server extends EventEmitter {
     const dht = this.dht
     function onabort() {
       if (!hs.relayPaired) dht.stats.relaying.aborts++
-      if (hs.relayTimeout) clearRelayTimeout(hs)
-      const socket = hs.relaySocket
-      hs.relayToken = null
-      hs.relaySocket = null
-      if (socket) socket.destroy()
+      destroyRelayConnection(hs)
       if (hs.aborted && hs.rawStream) hs.rawStream.destroy()
     }
   }
@@ -692,6 +693,30 @@ module.exports = class Server extends EventEmitter {
 function clearRelayTimeout(hs) {
   clearTimeout(hs.relayTimeout)
   hs.relayTimeout = null
+}
+
+function destroyRelayConnection(hs) {
+  const socket = resetRelayConnection(hs)
+
+  if (socket) socket.destroy()
+}
+
+function closeRelayConnection(hs) {
+  const socket = resetRelayConnection(hs)
+
+  if (socket) socket.end()
+}
+
+function resetRelayConnection(hs) {
+  if (hs.relayTimeout) clearRelayTimeout(hs)
+
+  const socket = hs.relaySocket
+  // Drop relay references so the app connection no longer keeps relay state alive.
+  hs.relayToken = null
+  hs.relaySocket = null
+  hs.relayClient = null
+
+  return socket
 }
 
 function isConsistent(fw) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -538,7 +538,17 @@ test('relay connection upgrades to direct connection', async function (t) {
 
   t.teardown(() => relayServer.close())
 
+  const relaySockets = []
+  let resolveRelaySockets = null
+  const relaySocketsOpened = new Promise((resolve) => {
+    resolveRelaySockets = resolve
+  })
+
   const relayTransportServer = relayNode.createServer(function (socket) {
+    relaySockets.push(socket)
+    // Wait until both client and server have opened their relay transport sockets.
+    if (relaySockets.length === 2) resolveRelaySockets(relaySockets)
+
     const session = relayServer.accept(socket, { id: socket.remotePublicKey })
     session.on('error', (err) => t.comment(err.message))
   })
@@ -571,6 +581,9 @@ test('relay connection upgrades to direct connection', async function (t) {
   })
 
   const [serverSocket] = await Promise.all([serverSocketOpened, once(clientSocket, 'open')])
+  await relaySocketsOpened
+
+  t.is(relaySockets.length, 2, 'both peers opened relay transport sockets')
 
   t.not(
     serverSocket.rawStream.remotePort,
@@ -590,9 +603,12 @@ test('relay connection upgrades to direct connection', async function (t) {
 
   const clientUpgraded = once(clientSocket.rawStream, 'remote-changed')
   const serverUpgraded = once(serverSocket.rawStream, 'remote-changed')
+  const relaySocketsClosed = relaySockets.map((socket) => once(socket, 'close'))
 
   resumePunching()
   await Promise.all([clientUpgraded, serverUpgraded])
+  await Promise.all(relaySocketsClosed)
+  t.pass('relay transport sockets close after direct upgrade')
 
   t.is(
     serverSocket.rawStream.remotePort,


### PR DESCRIPTION
#249 verifies that relayed connections can upgrade to a direct path in place: the raw stream starts relayed, emits `remote-changed`, switches to the peer address, and continues carrying data.

This PR adds the missing cleanup behavior for that path. Since relay sockets are currently opened per relayed connection, once both sides upgrade to direct there is no active use for the relay transport sockets anymore. Keeping them open leaves extra HyperDHT connections and keepalives around for the lifetime of the app connection.