### PR TITLE
Reuse relay connections across pairings

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,7 @@ const { FIREWALL, BOOTSTRAP_NODES, COMMANDS } = require('./lib/constants')
 const { hash, createKeyPair } = require('./lib/crypto')
 const RawStreamSet = require('./lib/raw-stream-set')
 const ConnectionPool = require('./lib/connection-pool')
+const RelayPool = require('./lib/relay-pool')
 const { STREAM_NOT_CONNECTED } = require('./lib/errors')
 
 const DEFAULTS = {
@@ -47,6 +48,7 @@ class HyperDHT extends DHT {
     }
     this.rawStreams = new RawStreamSet(this)
     this.plugins = new Map()
+    this._relayPool = new RelayPool(this)
 
     this._router = new Router(this, router)
     this._socketPool = new SocketPool(this, opts.host || '0.0.0.0')
@@ -129,6 +131,7 @@ class HyperDHT extends DHT {
     this._router.destroy()
     if (this._persistent) this._persistent.destroy()
     for (const plugin of this.plugins.values()) plugin.destroy()
+    await this._relayPool.destroy()
     await this.rawStreams.clear()
     await this._socketPool.destroy()
     await super.destroy()

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -101,6 +101,7 @@ module.exports = function connect(dht, publicKey, opts = {}) {
     relayToken: relayThrough ? relay.token() : null,
     relaySocket: null,
     relayClient: null,
+    relayPairing: null,
     relayPaired: false,
     validUpgrade: true,
     relayKeepAlive: opts.relayKeepAlive || 5000
@@ -806,12 +807,16 @@ function relayConnection(c, relayThrough, payload, hs) {
   }
 
   c.relayToken = token
-  c.relaySocket = c.dht.connect(publicKey)
-  c.relaySocket.setKeepAlive(c.relayKeepAlive)
-  c.relayClient = relay.Client.from(c.relaySocket, { id: c.relaySocket.publicKey })
+  c.relayPairing = c.dht._relayPool.pair(publicKey, {
+    isInitiator,
+    token,
+    stream: c.rawStream,
+    keepAlive: c.relayKeepAlive
+  })
+  c.relaySocket = c.relayPairing.socket
   c.relayTimeout = setTimeout(onabort, 15000, null)
 
-  c.relayClient.pair(isInitiator, token, c.rawStream).on('error', onabort).on('data', ondata)
+  c.relayPairing.on('error', onabort).on('data', ondata)
 
   function ondata(remoteId) {
     if (c.relayTimeout) clearRelayTimeout(c)
@@ -822,7 +827,9 @@ function relayConnection(c, relayThrough, payload, hs) {
 
     c.relayPaired = true
 
-    const { remotePort, remoteHost, socket } = c.relaySocket.rawStream
+    // Keep a stable reference since c.relaySocket is cleared after direct upgrade.
+    const relaySocket = c.relaySocket
+    const { remotePort, remoteHost, socket } = relaySocket.rawStream
 
     c.rawStream
       .on('close', () => destroyRelayConnection(c))

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -827,9 +827,7 @@ function relayConnection(c, relayThrough, payload, hs) {
 
     c.relayPaired = true
 
-    // Keep a stable reference since c.relaySocket is cleared after direct upgrade.
-    const relaySocket = c.relaySocket
-    const { remotePort, remoteHost, socket } = relaySocket.rawStream
+    const { remotePort, remoteHost, socket } = c.relaySocket.rawStream
 
     c.rawStream
       .on('close', () => destroyRelayConnection(c))

--- a/lib/relay-connection.js
+++ b/lib/relay-connection.js
@@ -12,9 +12,9 @@ function clearRelayTimeout(connectionOrHandshake) {
 }
 
 function closeRelayConnection(connectionOrHandshake) {
-  const relay = resetRelayConnection(connectionOrHandshake)
+  const pairing = resetRelayConnection(connectionOrHandshake)
 
-  if (relay) closeRelay(relay)
+  if (pairing) pairing.closePairing()
 }
 
 function confirmDirectUpgrade(connectionOrHandshake, rawStream, remoteChanging) {
@@ -54,31 +54,20 @@ function confirmDirectUpgrade(connectionOrHandshake, rawStream, remoteChanging) 
 }
 
 function destroyRelayConnection(connectionOrHandshake) {
-  const relay = resetRelayConnection(connectionOrHandshake)
+  const pairing = resetRelayConnection(connectionOrHandshake)
 
-  if (relay) destroyRelay(relay)
+  if (pairing) pairing.release()
 }
 
 function resetRelayConnection(connectionOrHandshake) {
   if (connectionOrHandshake.relayTimeout) clearRelayTimeout(connectionOrHandshake)
 
-  const relay = connectionOrHandshake.relayPairing || connectionOrHandshake.relaySocket
+  const pairing = connectionOrHandshake.relayPairing
   // Drop relay references so the app connection no longer keeps relay state alive.
   connectionOrHandshake.relayToken = null
   connectionOrHandshake.relaySocket = null
   connectionOrHandshake.relayClient = null
   connectionOrHandshake.relayPairing = null
 
-  return relay
-}
-
-function closeRelay(relay) {
-  if (relay.closePairing) return relay.closePairing()
-  if (relay.release) return relay.release()
-  relay.end()
-}
-
-function destroyRelay(relay) {
-  if (relay.release) return relay.release()
-  relay.destroy()
+  return pairing
 }

--- a/lib/relay-connection.js
+++ b/lib/relay-connection.js
@@ -12,9 +12,9 @@ function clearRelayTimeout(connectionOrHandshake) {
 }
 
 function closeRelayConnection(connectionOrHandshake) {
-  const socket = resetRelayConnection(connectionOrHandshake)
+  const relay = resetRelayConnection(connectionOrHandshake)
 
-  if (socket) socket.end()
+  if (relay) closeRelay(relay)
 }
 
 function confirmDirectUpgrade(connectionOrHandshake, rawStream, remoteChanging) {
@@ -54,19 +54,31 @@ function confirmDirectUpgrade(connectionOrHandshake, rawStream, remoteChanging) 
 }
 
 function destroyRelayConnection(connectionOrHandshake) {
-  const socket = resetRelayConnection(connectionOrHandshake)
+  const relay = resetRelayConnection(connectionOrHandshake)
 
-  if (socket) socket.destroy()
+  if (relay) destroyRelay(relay)
 }
 
 function resetRelayConnection(connectionOrHandshake) {
   if (connectionOrHandshake.relayTimeout) clearRelayTimeout(connectionOrHandshake)
 
-  const socket = connectionOrHandshake.relaySocket
+  const relay = connectionOrHandshake.relayPairing || connectionOrHandshake.relaySocket
   // Drop relay references so the app connection no longer keeps relay state alive.
   connectionOrHandshake.relayToken = null
   connectionOrHandshake.relaySocket = null
   connectionOrHandshake.relayClient = null
+  connectionOrHandshake.relayPairing = null
 
-  return socket
+  return relay
+}
+
+function closeRelay(relay) {
+  if (relay.closePairing) return relay.closePairing()
+  if (relay.release) return relay.release()
+  relay.end()
+}
+
+function destroyRelay(relay) {
+  if (relay.release) return relay.release()
+  relay.destroy()
 }

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -52,7 +52,7 @@ class RelayPoolEntry {
     this.socket = pool._dht.connect(publicKey)
     this.client = relay.Client.from(this.socket, { id: this.socket.publicKey })
     this.pairings = new Map()
-    this.pendingReleases = 0
+    this.pendingReleaseTimers = new Set()
     this.destroyed = false
 
     this._onclose = this._onclose.bind(this)
@@ -84,12 +84,14 @@ class RelayPoolEntry {
     if (!this.pairings.delete(pairing.keyString)) return
 
     if (unpair && delay > 0 && !this.destroyed) {
-      this.pendingReleases++
-      setTimeout(() => {
-        this.pendingReleases--
+      const timer = setTimeout(() => {
+        this.pendingReleaseTimers.delete(timer)
         if (!this.destroyed) unpairRelay(this.client, pairing.token)
         this._closeMaybe(unpair)
       }, delay)
+
+      this.pendingReleaseTimers.add(timer)
+      if (timer.unref) timer.unref()
       return
     }
 
@@ -103,6 +105,7 @@ class RelayPoolEntry {
 
     this.destroyed = true
     this.pool._delete(this)
+    this._clearPendingReleaseTimers()
     this.socket.off('close', this._onclose)
     if (graceful) this.socket.end()
     else this.socket.destroy()
@@ -113,6 +116,7 @@ class RelayPoolEntry {
 
     this.destroyed = true
     this.pool._delete(this)
+    this._clearPendingReleaseTimers()
 
     for (const pairing of this.pairings.values()) {
       pairing.detach()
@@ -127,12 +131,18 @@ class RelayPoolEntry {
   }
 
   _closeMaybe(graceful) {
-    if (this.pairings.size === 0 && this.pendingReleases === 0) this.close(graceful)
+    if (this.pairings.size === 0 && this.pendingReleaseTimers.size === 0) this.close(graceful)
+  }
+
+  _clearPendingReleaseTimers() {
+    for (const timer of this.pendingReleaseTimers) clearTimeout(timer)
+    this.pendingReleaseTimers.clear()
   }
 
   _onclose() {
     this.destroyed = true
     this.pool._delete(this)
+    this._clearPendingReleaseTimers()
 
     for (const pairing of this.pairings.values()) {
       pairing.destroy()

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -1,0 +1,203 @@
+const { EventEmitter, once } = require('events')
+const b4a = require('b4a')
+const relay = require('blind-relay')
+
+// Direct upgrade is observed locally first; defer unpairing so the peer can switch too.
+const DIRECT_UPGRADE_UNPAIR_DELAY = 1000
+
+module.exports = class RelayPool {
+  constructor(dht) {
+    this._dht = dht
+    this._entries = new Map()
+  }
+
+  pair(publicKey, opts) {
+    return this._get(publicKey, opts.keepAlive).pair(opts)
+  }
+
+  async destroy() {
+    const closing = []
+
+    for (const entry of this._entries.values()) {
+      closing.push(entry.destroy())
+    }
+
+    await Promise.allSettled(closing)
+  }
+
+  _get(publicKey, keepAlive) {
+    const keyString = b4a.toString(publicKey, 'hex')
+    let entry = this._entries.get(keyString)
+
+    if (!entry || entry.destroyed) {
+      entry = new RelayPoolEntry(this, keyString, publicKey, keepAlive)
+      this._entries.set(keyString, entry)
+    } else {
+      entry.setKeepAlive(keepAlive)
+    }
+
+    return entry
+  }
+
+  _delete(entry) {
+    if (this._entries.get(entry.keyString) === entry) this._entries.delete(entry.keyString)
+  }
+}
+
+class RelayPoolEntry {
+  constructor(pool, keyString, publicKey, keepAlive) {
+    this.pool = pool
+    this.keyString = keyString
+    this.socket = pool._dht.connect(publicKey)
+    this.client = relay.Client.from(this.socket, { id: this.socket.publicKey })
+    this.pairings = new Map()
+    this.pendingReleases = 0
+    this.destroyed = false
+
+    this._onclose = this._onclose.bind(this)
+    this.socket.once('close', this._onclose)
+    this.socket.on('error', noop)
+    this.setKeepAlive(keepAlive)
+  }
+
+  setKeepAlive(keepAlive) {
+    this.socket.setKeepAlive(keepAlive)
+  }
+
+  pair({ isInitiator, token, stream }) {
+    const request = this.client.pair(isInitiator, token, stream)
+    const pairing = new RelayPoolPairing(this, token, request)
+
+    this.pairings.set(pairing.keyString, pairing)
+
+    return pairing
+  }
+
+  release(pairing, unpair, delay = 0) {
+    if (!this.pairings.delete(pairing.keyString)) return
+
+    if (unpair && delay > 0 && !this.destroyed) {
+      this.pendingReleases++
+      setTimeout(() => {
+        this.pendingReleases--
+        if (!this.destroyed) unpairRelay(this.client, pairing.token)
+        this._closeMaybe(unpair)
+      }, delay)
+      return
+    }
+
+    if (unpair && !this.destroyed) unpairRelay(this.client, pairing.token)
+
+    this._closeMaybe(unpair)
+  }
+
+  close(graceful = true) {
+    if (this.destroyed) return
+
+    this.destroyed = true
+    this.pool._delete(this)
+    this.socket.off('close', this._onclose)
+    if (graceful) this.socket.end()
+    else this.socket.destroy()
+  }
+
+  async destroy() {
+    if (this.destroyed) return
+
+    this.destroyed = true
+    this.pool._delete(this)
+
+    for (const pairing of this.pairings.values()) {
+      pairing.detach()
+    }
+
+    this.pairings.clear()
+    this.socket.off('close', this._onclose)
+
+    const closed = this.socket.destroyed ? null : once(this.socket, 'close')
+    this.socket.destroy()
+    if (closed) await closed
+  }
+
+  _closeMaybe(graceful) {
+    if (this.pairings.size === 0 && this.pendingReleases === 0) this.close(graceful)
+  }
+
+  _onclose() {
+    this.destroyed = true
+    this.pool._delete(this)
+
+    for (const pairing of this.pairings.values()) {
+      pairing.destroy()
+    }
+
+    this.pairings.clear()
+  }
+}
+
+class RelayPoolPairing extends EventEmitter {
+  constructor(entry, token, request) {
+    super()
+
+    this.entry = entry
+    this.token = token
+    this.keyString = token.toString('hex')
+    this.request = request
+    this.released = false
+
+    this._ondata = this._ondata.bind(this)
+    this._onerror = this._onerror.bind(this)
+
+    request.on('data', this._ondata)
+    request.on('error', this._onerror)
+  }
+
+  get socket() {
+    return this.entry.socket
+  }
+
+  release() {
+    this._release(true)
+  }
+
+  closePairing() {
+    this._release(true, DIRECT_UPGRADE_UNPAIR_DELAY)
+  }
+
+  detach() {
+    this._release(false)
+  }
+
+  destroy() {
+    this._release(false)
+    this.request.stream.destroy()
+  }
+
+  _release(unpair, delay = 0) {
+    if (this.released) return
+    this.released = true
+
+    this.request.off('data', this._ondata)
+    this.request.off('error', this._onerror)
+    this.request.on('error', noop)
+
+    this.entry.release(this, unpair, delay)
+  }
+
+  _ondata(data) {
+    this.emit('data', data)
+  }
+
+  _onerror(err) {
+    if (this.listenerCount('error') === 0) return
+    this.emit('error', err)
+  }
+}
+
+function noop() {}
+
+function unpairRelay(client, token) {
+  try {
+    client.unpair(token)
+  } catch {}
+}

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -2,8 +2,9 @@ const { EventEmitter, once } = require('events')
 const b4a = require('b4a')
 const relay = require('blind-relay')
 
-// Direct upgrade is observed locally first; defer unpairing so the peer can switch too.
-const DIRECT_UPGRADE_UNPAIR_DELAY = 1000
+// Direct upgrade is observed locally first; keep the relay pairing briefly so
+// the peer can finish switching direct before the relay receives an unpair.
+const DIRECT_UPGRADE_UNPAIR_DELAY = 10000
 
 module.exports = class RelayPool {
   constructor(dht) {
@@ -29,7 +30,7 @@ module.exports = class RelayPool {
     const keyString = b4a.toString(publicKey, 'hex')
     let entry = this._entries.get(keyString)
 
-    if (!entry || entry.destroyed) {
+    if (!entry || !entry.reusable) {
       entry = new RelayPoolEntry(this, keyString, publicKey, keepAlive)
       this._entries.set(keyString, entry)
     } else {
@@ -58,6 +59,12 @@ class RelayPoolEntry {
     this.socket.once('close', this._onclose)
     this.socket.on('error', noop)
     this.setKeepAlive(keepAlive)
+  }
+
+  get reusable() {
+    return (
+      !this.destroyed && !this.socket.destroyed && !this.socket.destroying && !this.client.closed
+    )
   }
 
   setKeepAlive(keepAlive) {

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -31,7 +31,7 @@ module.exports = class RelayPool {
     let entry = this._entries.get(keyString)
 
     if (!entry || !entry.reusable) {
-      entry = new RelayPoolEntry(this, keyString, publicKey, keepAlive)
+      entry = new RelayPoolConnection(this, keyString, publicKey, keepAlive)
       this._entries.set(keyString, entry)
     }
 
@@ -43,7 +43,7 @@ module.exports = class RelayPool {
   }
 }
 
-class RelayPoolEntry {
+class RelayPoolConnection {
   constructor(pool, keyString, publicKey, keepAlive) {
     this.pool = pool
     this.keyString = keyString

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -1,4 +1,4 @@
-const { EventEmitter, once } = require('events')
+const { EventEmitter } = require('events')
 const b4a = require('b4a')
 const relay = require('blind-relay')
 
@@ -122,7 +122,9 @@ class RelayPoolConnection {
     if (!this._closeState()) return
 
     this._releasePairings(false)
-    const closed = this.socket.destroyed ? null : once(this.socket, 'close')
+    const closed = this.socket.destroyed
+      ? null
+      : new Promise((resolve) => this.socket.once('close', resolve))
     this.socket.destroy()
     if (closed) await closed
   }

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -27,14 +27,12 @@ module.exports = class RelayPool {
   }
 
   _get(publicKey, keepAlive) {
-    const keyString = b4a.toString(publicKey, 'hex')
+    const keyString = `${b4a.toString(publicKey, 'hex')}:${keepAlive}`
     let entry = this._entries.get(keyString)
 
     if (!entry || !entry.reusable) {
       entry = new RelayPoolEntry(this, keyString, publicKey, keepAlive)
       this._entries.set(keyString, entry)
-    } else {
-      entry.setKeepAlive(keepAlive)
     }
 
     return entry
@@ -58,17 +56,13 @@ class RelayPoolEntry {
     this._onclose = this._onclose.bind(this)
     this.socket.once('close', this._onclose)
     this.socket.on('error', noop)
-    this.setKeepAlive(keepAlive)
+    this.socket.setKeepAlive(keepAlive)
   }
 
   get reusable() {
     return (
       !this.destroyed && !this.socket.destroyed && !this.socket.destroying && !this.client.closed
     )
-  }
-
-  setKeepAlive(keepAlive) {
-    this.socket.setKeepAlive(keepAlive)
   }
 
   pair({ isInitiator, token, stream }) {

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -95,30 +95,16 @@ class RelayPoolConnection {
   }
 
   close(graceful = true) {
-    if (this.destroyed) return
+    if (!this._closeState()) return
 
-    this.destroyed = true
-    this.pool._delete(this)
-    this._clearPendingReleaseTimers()
-    this.socket.off('close', this._onclose)
     if (graceful) this.socket.end()
     else this.socket.destroy()
   }
 
   async destroy() {
-    if (this.destroyed) return
+    if (!this._closeState()) return
 
-    this.destroyed = true
-    this.pool._delete(this)
-    this._clearPendingReleaseTimers()
-
-    for (const pairing of this.pairings.values()) {
-      pairing.detach()
-    }
-
-    this.pairings.clear()
-    this.socket.off('close', this._onclose)
-
+    this._releasePairings(false)
     const closed = this.socket.destroyed ? null : once(this.socket, 'close')
     this.socket.destroy()
     if (closed) await closed
@@ -134,12 +120,26 @@ class RelayPoolConnection {
   }
 
   _onclose() {
+    if (!this._closeState()) return
+
+    this._releasePairings(true)
+  }
+
+  _closeState() {
+    if (this.destroyed) return false
+
     this.destroyed = true
     this.pool._delete(this)
     this._clearPendingReleaseTimers()
+    this.socket.off('close', this._onclose)
 
+    return true
+  }
+
+  _releasePairings(destroy) {
     for (const pairing of this.pairings.values()) {
-      pairing.destroy()
+      if (destroy) pairing.destroy()
+      else pairing.detach()
     }
 
     this.pairings.clear()

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -9,7 +9,7 @@ const DIRECT_UPGRADE_UNPAIR_DELAY = 10000
 module.exports = class RelayPool {
   constructor(dht) {
     this._dht = dht
-    this._entries = new Map()
+    this._connections = new Map()
   }
 
   pair(publicKey, opts) {
@@ -19,8 +19,8 @@ module.exports = class RelayPool {
   async destroy() {
     const closing = []
 
-    for (const entry of this._entries.values()) {
-      closing.push(entry.destroy())
+    for (const connection of this._connections.values()) {
+      closing.push(connection.destroy())
     }
 
     await Promise.allSettled(closing)
@@ -28,20 +28,22 @@ module.exports = class RelayPool {
 
   _get(publicKey, keepAlive) {
     const keyString = b4a.toString(publicKey, 'hex')
-    let entry = this._entries.get(keyString)
+    let connection = this._connections.get(keyString)
 
-    if (!entry || !entry.reusable) {
-      entry = new RelayPoolConnection(this, keyString, publicKey, keepAlive)
-      this._entries.set(keyString, entry)
+    if (!connection || !connection.reusable) {
+      connection = new RelayPoolConnection(this, keyString, publicKey, keepAlive)
+      this._connections.set(keyString, connection)
     } else {
-      entry.setKeepAlive(keepAlive)
+      connection.setKeepAlive(keepAlive)
     }
 
-    return entry
+    return connection
   }
 
-  _delete(entry) {
-    if (this._entries.get(entry.keyString) === entry) this._entries.delete(entry.keyString)
+  _delete(connection) {
+    if (this._connections.get(connection.keyString) === connection) {
+      this._connections.delete(connection.keyString)
+    }
   }
 }
 
@@ -157,10 +159,10 @@ class RelayPoolConnection {
 }
 
 class RelayPoolPairing extends EventEmitter {
-  constructor(entry, token, request) {
+  constructor(connection, token, request) {
     super()
 
-    this.entry = entry
+    this.connection = connection
     this.token = token
     this.keyString = token.toString('hex')
     this.request = request
@@ -174,7 +176,7 @@ class RelayPoolPairing extends EventEmitter {
   }
 
   get socket() {
-    return this.entry.socket
+    return this.connection.socket
   }
 
   release() {
@@ -202,7 +204,7 @@ class RelayPoolPairing extends EventEmitter {
     this.request.off('error', this._onerror)
     this.request.on('error', noop)
 
-    this.entry.release(this, unpair, delay)
+    this.connection.release(this, unpair, delay)
   }
 
   _ondata(data) {

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -30,7 +30,12 @@ module.exports = class RelayPool {
     const keyString = b4a.toString(publicKey, 'hex')
     let connection = this._connections.get(keyString)
 
-    if (!connection || !connection.reusable) {
+    if (connection && !connection.reusable) {
+      connection.destroy().catch(noop)
+      connection = null
+    }
+
+    if (!connection) {
       connection = new RelayPoolConnection(this, keyString, publicKey, keepAlive)
       this._connections.set(keyString, connection)
     } else {

--- a/lib/relay-pool.js
+++ b/lib/relay-pool.js
@@ -27,12 +27,14 @@ module.exports = class RelayPool {
   }
 
   _get(publicKey, keepAlive) {
-    const keyString = `${b4a.toString(publicKey, 'hex')}:${keepAlive}`
+    const keyString = b4a.toString(publicKey, 'hex')
     let entry = this._entries.get(keyString)
 
     if (!entry || !entry.reusable) {
       entry = new RelayPoolConnection(this, keyString, publicKey, keepAlive)
       this._entries.set(keyString, entry)
+    } else {
+      entry.setKeepAlive(keepAlive)
     }
 
     return entry
@@ -52,11 +54,12 @@ class RelayPoolConnection {
     this.pairings = new Map()
     this.pendingReleaseTimers = new Set()
     this.destroyed = false
+    this.keepAlive = keepAlive
 
     this._onclose = this._onclose.bind(this)
     this.socket.once('close', this._onclose)
     this.socket.on('error', noop)
-    this.socket.setKeepAlive(keepAlive)
+    this.socket.setKeepAlive(this.keepAlive)
   }
 
   get reusable() {
@@ -72,6 +75,13 @@ class RelayPoolConnection {
     this.pairings.set(pairing.keyString, pairing)
 
     return pairing
+  }
+
+  setKeepAlive(keepAlive) {
+    if (keepAlive >= this.keepAlive) return
+
+    this.keepAlive = keepAlive
+    this.socket.setKeepAlive(this.keepAlive)
   }
 
   release(pairing, unpair, delay = 0) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -660,9 +660,7 @@ module.exports = class Server extends EventEmitter {
       if (hs.prepunching) clearTimeout(hs.prepunching)
       hs.prepunching = null
 
-      // Keep a stable reference since hs.relaySocket is cleared after direct upgrade.
-      const relaySocket = hs.relaySocket
-      const { remotePort, remoteHost, socket } = relaySocket.rawStream
+      const { remotePort, remoteHost, socket } = hs.relaySocket.rawStream
 
       hs.rawStream
         .on('close', () => destroyRelayConnection(hs))

--- a/lib/server.js
+++ b/lib/server.js
@@ -407,7 +407,16 @@ module.exports = class Server extends EventEmitter {
     }
 
     if (relayThrough || remotePayload.relayThrough) {
-      this._relayConnection(hs, relayThrough, remotePayload, h)
+      try {
+        this._relayConnection(hs, relayThrough, remotePayload, h)
+      } catch (err) {
+        safetyCatch(err)
+        if (!hs.relayPaired) this.dht.stats.relaying.aborts++
+        destroyRelayConnection(hs)
+        if (hs.rawStream) hs.rawStream.destroy()
+        this._clearLater(hs, id, k)
+        return null
+      }
     }
 
     const onabort = () => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -235,6 +235,7 @@ module.exports = class Server extends EventEmitter {
       relayToken: null,
       relaySocket: null,
       relayClient: null,
+      relayPairing: null,
       relayPaired: false,
       validUpgrade: true
     }
@@ -637,40 +638,43 @@ module.exports = class Server extends EventEmitter {
     }
 
     hs.relayToken = token
-    hs.relaySocket = this.dht.connect(publicKey)
-    hs.relaySocket.setKeepAlive(this.relayKeepAlive)
-    hs.relayClient = relay.Client.from(hs.relaySocket, { id: hs.relaySocket.publicKey })
+    hs.relayPairing = this.dht._relayPool.pair(publicKey, {
+      isInitiator,
+      token,
+      stream: hs.rawStream,
+      keepAlive: this.relayKeepAlive
+    })
+    hs.relaySocket = hs.relayPairing.socket
     hs.relayTimeout = setTimeout(onabort, 15000)
 
-    hs.relayClient
-      .pair(isInitiator, token, hs.rawStream)
-      .on('error', onabort)
-      .on('data', (remoteId) => {
-        if (hs.relayTimeout) clearRelayTimeout(hs)
-        if (hs.rawStream === null) {
-          onabort(null)
-          return
-        }
+    hs.relayPairing.on('error', onabort).on('data', (remoteId) => {
+      if (hs.relayTimeout) clearRelayTimeout(hs)
+      if (hs.rawStream === null) {
+        onabort(null)
+        return
+      }
 
-        hs.relayPaired = true
-        this.dht.stats.relaying.successes++
+      hs.relayPaired = true
+      this.dht.stats.relaying.successes++
 
-        if (hs.prepunching) clearTimeout(hs.prepunching)
-        hs.prepunching = null
+      if (hs.prepunching) clearTimeout(hs.prepunching)
+      hs.prepunching = null
 
-        const { remotePort, remoteHost, socket } = hs.relaySocket.rawStream
+      // Keep a stable reference since hs.relaySocket is cleared after direct upgrade.
+      const relaySocket = hs.relaySocket
+      const { remotePort, remoteHost, socket } = relaySocket.rawStream
 
-        hs.rawStream
-          .on('close', () => destroyRelayConnection(hs))
-          .connect(socket, remoteId, remotePort, remoteHost)
+      hs.rawStream
+        .on('close', () => destroyRelayConnection(hs))
+        .connect(socket, remoteId, remotePort, remoteHost)
 
-        hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {
-          handshake: h,
-          keepAlive: this.dht.connectionKeepAlive
-        })
-
-        this.onconnection(hs.encryptedSocket)
+      hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {
+        handshake: h,
+        keepAlive: this.dht.connectionKeepAlive
       })
+
+      this.onconnection(hs.encryptedSocket)
+    })
 
     const dht = this.dht
     function onabort() {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1011,11 +1011,6 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   )
   t.absent(relaySocket.destroying, 'relay transport is not closing')
 
-  secondPairing.release()
-  secondStream.destroy()
-
-  await waitFor(() => clientNode._relayPool._connections.size === 0)
-
   await clientNode.destroy()
   await relayNode.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -839,10 +839,6 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
 
   t.not(secondPairing.socket, closingSocket, 'new pairing gets a fresh relay transport')
 
-  firstStream.destroy()
-  secondStream.destroy()
-  secondPairing.release()
-
   await clientNode.destroy()
   await relayNode.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -895,6 +895,7 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   })
   const closingSocket = firstPairing.socket
 
+  // Simulate the close-event race where the pool entry still exists but its transport is closing.
   closingSocket.destroy()
 
   const secondStream = clientNode.createRawStream({ framed: true })
@@ -910,6 +911,87 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   firstStream.destroy()
   secondStream.destroy()
   secondPairing.release()
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
+test('relay pool unrefs and clears delayed direct-upgrade unpairs', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const rawStream = clientNode.createRawStream({ framed: true })
+  const pairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: rawStream,
+    keepAlive: 5000
+  })
+
+  await waitFor(() => relay._pairing.size === 1)
+
+  // The direct-upgrade unpair delay is intentionally long, so wrap the timer to
+  // verify cleanup behavior without waiting for the delay to elapse.
+  const setTimeoutOriginal = global.setTimeout
+  const clearTimeoutOriginal = global.clearTimeout
+  let delayedTimer = null
+  let unrefed = false
+  let cleared = false
+
+  global.setTimeout = function (fn, delay, ...args) {
+    const timer = setTimeoutOriginal.call(this, fn, delay, ...args)
+
+    if (delay > 1000) {
+      delayedTimer = {
+        timer,
+        unref() {
+          unrefed = true
+          if (timer.unref) return timer.unref()
+        }
+      }
+
+      return delayedTimer
+    }
+
+    return timer
+  }
+
+  global.clearTimeout = function (timer) {
+    if (timer === delayedTimer) cleared = true
+    return clearTimeoutOriginal.call(this, timer === delayedTimer ? delayedTimer.timer : timer)
+  }
+
+  t.teardown(function () {
+    global.setTimeout = setTimeoutOriginal
+    global.clearTimeout = clearTimeoutOriginal
+    if (delayedTimer !== null) clearTimeoutOriginal(delayedTimer.timer)
+  })
+
+  // closePairing is the direct-upgrade cleanup path that schedules delayed unpair.
+  pairing.closePairing()
+  rawStream.destroy()
+
+  t.ok(unrefed, 'delayed unpair timer is unrefed')
+
+  await clientNode._relayPool.destroy()
+  t.ok(cleared, 'delayed unpair timer is cleared on pool destroy')
 
   await clientNode.destroy()
   await relayNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -651,9 +651,7 @@ test('relay connections through same node reuse transport sockets', async functi
   t.alike(await firstReply, [Buffer.from('hello 1')], 'first relayed connection carries data')
   t.alike(await secondReply, [Buffer.from('hello 2')], 'second relayed connection carries data')
 
-  const firstServerClosed = once(firstServerSocket, 'close')
   await endAndCloseSocket(firstClientSocket)
-  await firstServerClosed
   await firstPairingReleased
   t.is(closedRelayStreams, 2, 'closing one app connection releases only its relay pairing')
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -702,16 +702,7 @@ test('relay pool closes app streams when shared transports close', async functio
   const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
   const relaySockets = []
-  let resolveRelaySockets = null
-  const relaySocketsOpened = new Promise((resolve) => {
-    resolveRelaySockets = resolve
-  })
-
   const serverSockets = []
-  let resolveServerSockets = null
-  const serverSocketsOpened = new Promise((resolve) => {
-    resolveServerSockets = resolve
-  })
 
   const relay = new RelayServer({
     createStream(opts) {
@@ -723,7 +714,6 @@ test('relay pool closes app streams when shared transports close', async functio
 
   const relayTransportServer = relayNode.createServer(function (socket) {
     relaySockets.push(socket)
-    if (relaySockets.length === 2) resolveRelaySockets()
 
     const session = relay.accept(socket, { id: socket.remotePublicKey })
     session.on('error', () => {})
@@ -739,7 +729,6 @@ test('relay pool closes app streams when shared transports close', async functio
     },
     function (socket) {
       serverSockets.push(socket)
-      if (serverSockets.length === 2) resolveServerSockets()
 
       socket.on('data', (data) => socket.write(data))
       socket.on('end', () => socket.end())
@@ -759,11 +748,7 @@ test('relay pool closes app streams when shared transports close', async functio
     })
   ]
 
-  await Promise.all([
-    relaySocketsOpened,
-    serverSocketsOpened,
-    ...clientSockets.map((socket) => once(socket, 'open'))
-  ])
+  await Promise.all(clientSockets.map((socket) => once(socket, 'open')))
 
   t.is(clientNode._relayPool._connections.size, 1, 'client has one shared relay pool connection')
   t.is(serverNode._relayPool._connections.size, 1, 'server has one shared relay pool connection')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1128,6 +1128,8 @@ test('relay pool keeps transport open for pairings started during delayed unpair
 })
 
 test('relay connection upgrades to direct connection', async function (t) {
+  t.timeout(90000)
+
   for (const opts of [
     { name: 'default keepalive' },
     { name: 'without keepalive', connectionKeepAlive: false, confirmWithAppData: true },

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1078,7 +1078,6 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   secondPairing.release()
   secondStream.destroy()
 
-  await clientNode._relayPool.destroy()
   await waitFor(() => clientNode._relayPool._connections.size === 0)
 
   await clientNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1,7 +1,9 @@
 const test = require('brittle')
 const { once } = require('events')
-const RelayServer = require('blind-relay').Server
+const BlindRelay = require('blind-relay')
+const RelayServer = BlindRelay.Server
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
+const DHT = require('../')
 const Holepuncher = require('../lib/holepuncher')
 const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 
@@ -211,6 +213,12 @@ async function waitFor(fn, timeout = 2000) {
 
     await new Promise((resolve) => setTimeout(resolve, 20))
   }
+}
+
+function getOnlyRelayPoolEntry(node) {
+  const entries = [...node._relayPool._entries.values()]
+  if (entries.length !== 1) throw new Error('Expected exactly one relay pool entry')
+  return entries[0]
 }
 
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
@@ -541,6 +549,322 @@ test('relay connections through node, client and server side', async function (t
   await a.destroy()
 })
 
+test('relay connections through same node reuse transport sockets', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relaySockets = []
+  let closedRelaySockets = 0
+  let resolveRelaySockets = null
+  const relaySocketsOpened = new Promise((resolve) => {
+    resolveRelaySockets = resolve
+  })
+
+  const serverSockets = []
+  let resolveServerSockets = null
+  const serverSocketsOpened = new Promise((resolve) => {
+    resolveServerSockets = resolve
+  })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayStreams = []
+  let closedRelayStreams = 0
+  let resolveRelayStreamsPaired = null
+  const relayStreamsPaired = new Promise((resolve) => {
+    resolveRelayStreamsPaired = resolve
+  })
+  let resolveFirstPairingReleased = null
+  const firstPairingReleased = new Promise((resolve) => {
+    resolveFirstPairingReleased = resolve
+  })
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    relaySockets.push(socket)
+    socket.once('close', function () {
+      closedRelaySockets++
+    })
+    // Wait until both peers have opened their shared relay transport sockets.
+    if (relaySockets.length === 2) resolveRelaySockets()
+
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('pair', function (_, __, stream) {
+      relayStreams.push(stream)
+      if (relayStreams.length === 4) resolveRelayStreamsPaired()
+
+      stream.once('close', function () {
+        closedRelayStreams++
+        if (closedRelayStreams === 2) resolveFirstPairingReleased()
+      })
+    })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const appServer = serverNode.createServer(
+    {
+      holepunch: false,
+      shareLocalAddress: false,
+      relayThrough: relayTransportServer.publicKey
+    },
+    function (socket) {
+      serverSockets.push(socket)
+      if (serverSockets.length === 2) resolveServerSockets()
+
+      socket.on('data', (data) => socket.write(data))
+      socket.on('end', () => socket.end())
+    }
+  )
+
+  await appServer.listen()
+
+  const clientSockets = [
+    clientNode.connect(appServer.publicKey, {
+      holepunch: false,
+      localConnection: false,
+      relayThrough: relayTransportServer.publicKey
+    }),
+    clientNode.connect(appServer.publicKey, {
+      holepunch: false,
+      localConnection: false,
+      relayThrough: relayTransportServer.publicKey
+    })
+  ]
+
+  await Promise.all([
+    relaySocketsOpened,
+    relayStreamsPaired,
+    serverSocketsOpened,
+    ...clientSockets.map((socket) => once(socket, 'open'))
+  ])
+
+  t.is(relaySockets.length, 2, 'both peers reuse one transport socket to the relay')
+
+  const replies = clientSockets.map((socket) => once(socket, 'data'))
+  clientSockets[0].write(Buffer.from('hello 1'))
+  clientSockets[1].write(Buffer.from('hello 2'))
+
+  t.alike((await replies[0])[0], Buffer.from('hello 1'), 'first relayed connection carries data')
+  t.alike((await replies[1])[0], Buffer.from('hello 2'), 'second relayed connection carries data')
+
+  const firstServerClosed = Promise.race(serverSockets.map((socket) => once(socket, 'close')))
+  await endAndCloseSocket(clientSockets[0])
+  await firstServerClosed
+  await firstPairingReleased
+  t.is(closedRelayStreams, 2, 'closing one app connection releases only its relay pairing')
+
+  const secondReply = once(clientSockets[1], 'data')
+  clientSockets[1].write(Buffer.from('still relayed'))
+  t.alike(
+    (await secondReply)[0],
+    Buffer.from('still relayed'),
+    'second relayed connection stays usable after first closes'
+  )
+
+  await endAndCloseSocket(clientSockets[1])
+
+  for (const socket of serverSockets) {
+    if (!socket.destroyed) await once(socket, 'close')
+  }
+
+  await waitFor(() => closedRelaySockets === 2)
+  t.is(closedRelaySockets, 2, 'shared relay transports close after all pairings close')
+
+  const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
+  const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
+    holepunch: false,
+    localConnection: false,
+    relayThrough: relayTransportServer.publicKey
+  })
+
+  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocket])
+  await waitFor(() => relaySockets.length === 4)
+  t.is(relaySockets.length, 4, 'reconnect creates fresh relay transport sockets')
+
+  const reconnectedReply = once(reconnectedClientSocket, 'data')
+  reconnectedClientSocket.write(Buffer.from('reconnected'))
+  t.alike(
+    (await reconnectedReply)[0],
+    Buffer.from('reconnected'),
+    'reconnected relay path carries data'
+  )
+
+  await endAndCloseSocket(reconnectedClientSocket)
+  const lastServerSocket = serverSockets[serverSockets.length - 1]
+  if (!lastServerSocket.destroyed) await once(lastServerSocket, 'close')
+
+  await clientNode.destroy()
+  await serverNode.destroy()
+  await relayNode.destroy()
+})
+
+test('relay pool closes app streams when shared transports close', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relaySockets = []
+  let resolveRelaySockets = null
+  const relaySocketsOpened = new Promise((resolve) => {
+    resolveRelaySockets = resolve
+  })
+
+  const serverSockets = []
+  let resolveServerSockets = null
+  const serverSocketsOpened = new Promise((resolve) => {
+    resolveServerSockets = resolve
+  })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    relaySockets.push(socket)
+    if (relaySockets.length === 2) resolveRelaySockets()
+
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', () => {})
+  })
+
+  await relayTransportServer.listen()
+
+  const appServer = serverNode.createServer(
+    {
+      holepunch: false,
+      shareLocalAddress: false,
+      relayThrough: relayTransportServer.publicKey
+    },
+    function (socket) {
+      serverSockets.push(socket)
+      if (serverSockets.length === 2) resolveServerSockets()
+
+      socket.on('data', (data) => socket.write(data))
+      socket.on('end', () => socket.end())
+    }
+  )
+
+  await appServer.listen()
+
+  const clientSockets = [
+    clientNode.connect(appServer.publicKey, {
+      holepunch: false,
+      localConnection: false,
+      relayThrough: relayTransportServer.publicKey
+    }),
+    clientNode.connect(appServer.publicKey, {
+      holepunch: false,
+      localConnection: false,
+      relayThrough: relayTransportServer.publicKey
+    })
+  ]
+
+  await Promise.all([
+    relaySocketsOpened,
+    serverSocketsOpened,
+    ...clientSockets.map((socket) => once(socket, 'open'))
+  ])
+
+  t.is(clientNode._relayPool._entries.size, 1, 'client has one shared relay pool entry')
+  t.is(serverNode._relayPool._entries.size, 1, 'server has one shared relay pool entry')
+
+  const closed = [
+    ...clientSockets.map((socket) => once(socket, 'close')),
+    ...serverSockets.map((socket) => once(socket, 'close'))
+  ]
+
+  getOnlyRelayPoolEntry(clientNode).socket.destroy()
+  getOnlyRelayPoolEntry(serverNode).socket.destroy()
+
+  await Promise.all(closed)
+  t.pass('active app streams close when shared relay transports close')
+  t.is(clientNode._relayPool._entries.size, 0, 'client relay pool entry is removed')
+  t.is(serverNode._relayPool._entries.size, 0, 'server relay pool entry is removed')
+
+  const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
+  const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
+    holepunch: false,
+    localConnection: false,
+    relayThrough: relayTransportServer.publicKey
+  })
+
+  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocket])
+  await waitFor(() => relaySockets.length === 4)
+  t.is(relaySockets.length, 4, 'later reconnect creates fresh relay transports')
+
+  const reply = once(reconnectedClientSocket, 'data')
+  reconnectedClientSocket.write(Buffer.from('fresh relay'))
+  t.alike((await reply)[0], Buffer.from('fresh relay'), 'fresh relay transport carries data')
+
+  await endAndCloseSocket(reconnectedClientSocket)
+  const lastServerSocket = serverSockets[serverSockets.length - 1]
+  if (!lastServerSocket.destroyed) await once(lastServerSocket, 'close')
+
+  await clientNode.destroy()
+  await serverNode.destroy()
+  await relayNode.destroy()
+})
+
+test('relay pool unpairs if pairing aborts before remote pairs', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const rawStream = clientNode.createRawStream({ framed: true })
+  const pairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: rawStream,
+    keepAlive: 5000
+  })
+
+  await waitFor(() => relay._pairing.size === 1)
+  t.is(relay._pairing.size, 1, 'relay has one pending half-pairing')
+
+  pairing.release()
+  rawStream.destroy()
+
+  await waitFor(() => relay._pairing.size === 0)
+  await waitFor(() => clientNode._relayPool._entries.size === 0)
+  t.is(relay._pairing.size, 0, 'pending half-pairing is unpaired')
+  t.is(clientNode._relayPool._entries.size, 0, 'relay pool closes after aborted pairing')
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
 test('relay connection upgrades to direct connection', async function (t) {
   for (const opts of [
     { name: 'default keepalive' },
@@ -685,6 +1009,189 @@ test('relay connection upgrades to direct connection', async function (t) {
     await serverNode.destroy()
     await clientNode.destroy()
   }
+})
+
+test('direct upgrade keeps other pooled relay pairings alive', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const resumePunching = pausePunching(t, [serverNode, clientNode])
+
+  const relayServer = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relayServer.close())
+
+  const relaySockets = []
+  let closedRelaySockets = 0
+  let resolveRelaySockets = null
+  const relaySocketsOpened = new Promise((resolve) => {
+    resolveRelaySockets = resolve
+  })
+
+  const relayStreams = []
+  let closedRelayStreams = 0
+  let resolveRelayStreamsPaired = null
+  const relayStreamsPaired = new Promise((resolve) => {
+    resolveRelayStreamsPaired = resolve
+  })
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    relaySockets.push(socket)
+    socket.once('close', function () {
+      closedRelaySockets++
+    })
+    if (relaySockets.length === 2) resolveRelaySockets()
+
+    const session = relayServer.accept(socket, { id: socket.remotePublicKey })
+    session.on('pair', function (_, __, stream) {
+      relayStreams.push(stream)
+      if (relayStreams.length === 4) resolveRelayStreamsPaired()
+
+      stream.once('close', function () {
+        closedRelayStreams++
+      })
+    })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  let resolveUpgradeServerSocket = null
+  const upgradeServerSocketOpened = new Promise((resolve) => {
+    resolveUpgradeServerSocket = resolve
+  })
+  const upgradeServer = serverNode.createServer(
+    {
+      relayThrough: relayTransportServer.publicKey,
+      shareLocalAddress: false
+    },
+    function (socket) {
+      socket.on('error', (err) => t.comment(err.message))
+      resolveUpgradeServerSocket(socket)
+      socket.on('data', (data) => socket.write(data))
+      socket.on('end', () => socket.end())
+    }
+  )
+
+  await upgradeServer.listen(DHT.keyPair())
+
+  let resolveRelayOnlyServerSocket = null
+  const relayOnlyServerSocketOpened = new Promise((resolve) => {
+    resolveRelayOnlyServerSocket = resolve
+  })
+  const relayOnlyServer = serverNode.createServer(
+    {
+      relayThrough: relayTransportServer.publicKey,
+      shareLocalAddress: false
+    },
+    function (socket) {
+      socket.on('error', (err) => t.comment(err.message))
+      resolveRelayOnlyServerSocket(socket)
+      socket.on('data', (data) => socket.write(data))
+      socket.on('end', () => socket.end())
+    }
+  )
+
+  await relayOnlyServer.listen(DHT.keyPair())
+
+  const upgradeClientSocket = clientNode.connect(upgradeServer.publicKey, {
+    fastOpen: false,
+    localConnection: false
+  })
+  const relayOnlyClientSocket = clientNode.connect(relayOnlyServer.publicKey, {
+    fastOpen: false,
+    holepunch: () => false,
+    localConnection: false
+  })
+  upgradeClientSocket.on('error', (err) => t.comment(err.message))
+  relayOnlyClientSocket.on('error', (err) => t.comment(err.message))
+
+  const [upgradeServerSocket, relayOnlyServerSocket] = await Promise.all([
+    upgradeServerSocketOpened,
+    relayOnlyServerSocketOpened,
+    once(upgradeClientSocket, 'open'),
+    once(relayOnlyClientSocket, 'open')
+  ])
+  await Promise.all([relaySocketsOpened, relayStreamsPaired])
+
+  t.is(relaySockets.length, 2, 'both app connections share the relay transport sockets')
+  t.is(clientNode._relayPool._entries.size, 1, 'client has one shared relay pool entry')
+  t.is(serverNode._relayPool._entries.size, 1, 'server has one shared relay pool entry')
+
+  const beforeUpgrade = once(relayOnlyClientSocket, 'data')
+  relayOnlyClientSocket.write(Buffer.from('before direct upgrade'))
+  t.alike(
+    (await beforeUpgrade)[0],
+    Buffer.from('before direct upgrade'),
+    'relay-only connection carries data before another pairing upgrades'
+  )
+
+  let relayOnlyClientUpgraded = false
+  let relayOnlyServerUpgraded = false
+  relayOnlyClientSocket.rawStream.once('remote-changed', () => {
+    relayOnlyClientUpgraded = true
+  })
+  relayOnlyServerSocket.rawStream.once('remote-changed', () => {
+    relayOnlyServerUpgraded = true
+  })
+
+  const clientUpgraded = once(upgradeClientSocket.rawStream, 'remote-changed')
+  const serverUpgraded = once(upgradeServerSocket.rawStream, 'remote-changed')
+
+  resumePunching()
+  await Promise.all([clientUpgraded, serverUpgraded])
+  await waitFor(() => closedRelayStreams === 2)
+
+  t.is(closedRelayStreams, 2, 'direct upgrade releases only its relay pairing')
+  t.is(closedRelaySockets, 0, 'shared relay transports stay open for the other pairing')
+  t.absent(relayOnlyClientUpgraded, 'relay-only client does not upgrade to direct')
+  t.absent(relayOnlyServerUpgraded, 'relay-only server does not upgrade to direct')
+  t.not(
+    relayOnlyServerSocket.rawStream.remotePort,
+    relayOnlyClientSocket.rawStream.localPort,
+    'relay-only server stays on the relayed stream'
+  )
+  t.not(
+    relayOnlyClientSocket.rawStream.remotePort,
+    relayOnlyServerSocket.rawStream.localPort,
+    'relay-only client stays on the relayed stream'
+  )
+
+  const directReply = once(upgradeClientSocket, 'data')
+  upgradeClientSocket.write(Buffer.from('after direct upgrade'))
+  t.alike(
+    (await directReply)[0],
+    Buffer.from('after direct upgrade'),
+    'upgraded direct connection carries data'
+  )
+
+  const relayedReply = once(relayOnlyClientSocket, 'data')
+  relayOnlyClientSocket.write(Buffer.from('still relayed'))
+  t.alike(
+    (await relayedReply)[0],
+    Buffer.from('still relayed'),
+    'other pooled relay pairing stays usable after direct upgrade'
+  )
+
+  await endAndCloseSocket(upgradeClientSocket)
+  if (!upgradeServerSocket.destroyed) await once(upgradeServerSocket, 'close')
+
+  await endAndCloseSocket(relayOnlyClientSocket)
+  if (!relayOnlyServerSocket.destroyed) await once(relayOnlyServerSocket, 'close')
+
+  await waitFor(() => closedRelaySockets === 2)
+  t.is(closedRelaySockets, 2, 'shared relay transports close after remaining pairing closes')
+
+  await relayNode.destroy()
+  await serverNode.destroy()
+  await clientNode.destroy()
 })
 
 test.skip('relay several connections through node with pool', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -670,14 +670,12 @@ test('relay connections through same node reuse transport sockets', async functi
   await waitFor(() => closedRelaySockets === 2)
   t.is(closedRelaySockets, 2, 'shared relay transports close after all pairings close')
 
-  const reconnectedServerSocketOpened = waitFor(() => reconnectedServerSocket !== null)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
     localConnection: false,
     relayThrough: relayTransportServer.publicKey
   })
 
-  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocketOpened])
-  await waitFor(() => relaySockets.length === 4)
+  await once(reconnectedClientSocket, 'open')
   t.is(relaySockets.length, 4, 'reconnect creates fresh relay transport sockets')
 
   const reconnectedReply = once(reconnectedClientSocket, 'data')
@@ -783,14 +781,12 @@ test('relay pool closes app streams when shared transports close', async functio
   t.is(clientNode._relayPool._connections.size, 0, 'client relay pool connection is removed')
   t.is(serverNode._relayPool._connections.size, 0, 'server relay pool connection is removed')
 
-  const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
     localConnection: false,
     relayThrough: relayTransportServer.publicKey
   })
 
-  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocket])
-  await waitFor(() => relaySockets.length === 4)
+  await once(reconnectedClientSocket, 'open')
   t.is(relaySockets.length, 4, 'later reconnect creates fresh relay transports')
 
   const reply = once(reconnectedClientSocket, 'data')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -558,12 +558,8 @@ test('relay connections through same node reuse transport sockets', async functi
 
   const relaySockets = []
   let closedRelaySockets = 0
-  let resolveRelaySockets = null
-  const relaySocketsOpened = new Promise((resolve) => {
-    resolveRelaySockets = resolve
-  })
 
-  let firstServerSocket = null
+  let serverSocketCount = 0
   let secondServerSocket = null
   let reconnectedServerSocket = null
 
@@ -575,12 +571,7 @@ test('relay connections through same node reuse transport sockets', async functi
 
   t.teardown(() => relay.close())
 
-  const relayStreams = []
   let closedRelayStreams = 0
-  let resolveRelayStreamsPaired = null
-  const relayStreamsPaired = new Promise((resolve) => {
-    resolveRelayStreamsPaired = resolve
-  })
   let resolveFirstPairingReleased = null
   const firstPairingReleased = new Promise((resolve) => {
     resolveFirstPairingReleased = resolve
@@ -591,14 +582,9 @@ test('relay connections through same node reuse transport sockets', async functi
     socket.once('close', function () {
       closedRelaySockets++
     })
-    // Wait until both peers have opened their shared relay transport sockets.
-    if (relaySockets.length === 2) resolveRelaySockets()
 
     const session = relay.accept(socket, { id: socket.remotePublicKey })
     session.on('pair', function (_, __, stream) {
-      relayStreams.push(stream)
-      if (relayStreams.length === 4) resolveRelayStreamsPaired()
-
       stream.once('close', function () {
         closedRelayStreams++
         if (closedRelayStreams === 2) resolveFirstPairingReleased()
@@ -616,9 +602,9 @@ test('relay connections through same node reuse transport sockets', async functi
       relayThrough: relayTransportServer.publicKey
     },
     function (socket) {
-      if (firstServerSocket === null) firstServerSocket = socket
-      else if (secondServerSocket === null) secondServerSocket = socket
-      else reconnectedServerSocket = socket
+      serverSocketCount++
+      if (serverSocketCount === 2) secondServerSocket = socket
+      else if (serverSocketCount === 3) reconnectedServerSocket = socket
 
       socket.on('data', (data) => socket.write(data))
       socket.on('end', () => socket.end())
@@ -638,8 +624,6 @@ test('relay connections through same node reuse transport sockets', async functi
     relayThrough: relayTransportServer.publicKey
   })
   await once(secondClientSocket, 'open')
-
-  await Promise.all([relaySocketsOpened, relayStreamsPaired])
 
   t.is(relaySockets.length, 2, 'both peers reuse one transport socket to the relay')
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1061,6 +1061,7 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   t.is(secondPairing.socket, relaySocket, 'new pairing reuses the pending relay transport')
 
   await waitFor(() => relay._pairing.size === 2)
+  // The delayed unpair should remove only the first pairing.
   await waitFor(() => relay._pairing.size === 1)
   t.is(clientNode._relayPool._connections.size, 1, 'pool connection stays open for the new pairing')
   t.is(

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -203,24 +203,6 @@ test('relay connections through node, server side, client abort notifies remote'
   await c.destroy()
 })
 
-async function waitFor(fn, timeout = 2000) {
-  const started = Date.now()
-
-  while (!fn()) {
-    if (Date.now() - started > timeout) {
-      throw new Error('Timed out waiting for test condition')
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, 20))
-  }
-}
-
-function getOnlyRelayPoolConnection(node) {
-  const connections = [...node._relayPool._connections.values()]
-  if (connections.length !== 1) throw new Error('Expected exactly one relay pool connection')
-  return connections[0]
-}
-
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -1412,26 +1394,6 @@ test.skip('relay several connections through node with pool', async function (t)
   await c.destroy()
 })
 
-function pausePunching(t, pausedNodes) {
-  const punch = Holepuncher.prototype._punch
-  let resume = null
-  const punchingResumed = new Promise((resolve) => {
-    resume = resolve
-  })
-
-  Holepuncher.prototype._punch = async function () {
-    if (pausedNodes.includes(this.dht)) await punchingResumed
-    return punch.call(this)
-  }
-
-  t.teardown(() => {
-    resume()
-    Holepuncher.prototype._punch = punch
-  })
-
-  return resume
-}
-
 test.skip('server does not support connection relaying', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -1469,3 +1431,41 @@ test.skip('server does not support connection relaying', async function (t) {
   await b.destroy()
   await c.destroy()
 })
+
+async function waitFor(fn, timeout = 2000) {
+  const started = Date.now()
+
+  while (!fn()) {
+    if (Date.now() - started > timeout) {
+      throw new Error('Timed out waiting for test condition')
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+}
+
+function getOnlyRelayPoolConnection(node) {
+  const connections = [...node._relayPool._connections.values()]
+  if (connections.length !== 1) throw new Error('Expected exactly one relay pool connection')
+  return connections[0]
+}
+
+function pausePunching(t, pausedNodes) {
+  const punch = Holepuncher.prototype._punch
+  let resume = null
+  const punchingResumed = new Promise((resolve) => {
+    resume = resolve
+  })
+
+  Holepuncher.prototype._punch = async function () {
+    if (pausedNodes.includes(this.dht)) await punchingResumed
+    return punch.call(this)
+  }
+
+  t.teardown(() => {
+    resume()
+    Holepuncher.prototype._punch = punch
+  })
+
+  return resume
+}

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1282,18 +1282,15 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
 
   await relayTransportServer.listen()
 
-  let resolveUpgradeServerSocket = null
-  const upgradeServerSocketOpened = new Promise((resolve) => {
-    resolveUpgradeServerSocket = resolve
-  })
+  let upgradeServerSocket = null
   const upgradeServer = serverNode.createServer(
     {
       relayThrough: relayTransportServer.publicKey,
       shareLocalAddress: false
     },
     function (socket) {
+      upgradeServerSocket = socket
       socket.on('error', (err) => t.comment(err.message))
-      resolveUpgradeServerSocket(socket)
       socket.on('data', (data) => socket.write(data))
       socket.on('end', () => socket.end())
     }
@@ -1301,18 +1298,15 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
 
   await upgradeServer.listen(DHT.keyPair())
 
-  let resolveRelayOnlyServerSocket = null
-  const relayOnlyServerSocketOpened = new Promise((resolve) => {
-    resolveRelayOnlyServerSocket = resolve
-  })
+  let relayOnlyServerSocket = null
   const relayOnlyServer = serverNode.createServer(
     {
       relayThrough: relayTransportServer.publicKey,
       shareLocalAddress: false
     },
     function (socket) {
+      relayOnlyServerSocket = socket
       socket.on('error', (err) => t.comment(err.message))
-      resolveRelayOnlyServerSocket(socket)
       socket.on('data', (data) => socket.write(data))
       socket.on('end', () => socket.end())
     }
@@ -1332,12 +1326,7 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
   upgradeClientSocket.on('error', (err) => t.comment(err.message))
   relayOnlyClientSocket.on('error', (err) => t.comment(err.message))
 
-  const [upgradeServerSocket, relayOnlyServerSocket] = await Promise.all([
-    upgradeServerSocketOpened,
-    relayOnlyServerSocketOpened,
-    once(upgradeClientSocket, 'open'),
-    once(relayOnlyClientSocket, 'open')
-  ])
+  await Promise.all([once(upgradeClientSocket, 'open'), once(relayOnlyClientSocket, 'open')])
   await Promise.all([relaySocketsOpened, relayStreamsPaired])
 
   t.is(relaySockets.length, 2, 'both app connections share the relay transport sockets')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1203,30 +1203,17 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
 
   const relaySockets = []
   let closedRelaySockets = 0
-  let resolveRelaySockets = null
-  const relaySocketsOpened = new Promise((resolve) => {
-    resolveRelaySockets = resolve
-  })
 
-  const relayStreams = []
   let closedRelayStreams = 0
-  let resolveRelayStreamsPaired = null
-  const relayStreamsPaired = new Promise((resolve) => {
-    resolveRelayStreamsPaired = resolve
-  })
 
   const relayTransportServer = relayNode.createServer(function (socket) {
     relaySockets.push(socket)
     socket.once('close', function () {
       closedRelaySockets++
     })
-    if (relaySockets.length === 2) resolveRelaySockets()
 
     const session = relayServer.accept(socket, { id: socket.remotePublicKey })
     session.on('pair', function (_, __, stream) {
-      relayStreams.push(stream)
-      if (relayStreams.length === 4) resolveRelayStreamsPaired()
-
       stream.once('close', function () {
         closedRelayStreams++
       })
@@ -1281,7 +1268,6 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
   relayOnlyClientSocket.on('error', (err) => t.comment(err.message))
 
   await Promise.all([once(upgradeClientSocket, 'open'), once(relayOnlyClientSocket, 'open')])
-  await Promise.all([relaySocketsOpened, relayStreamsPaired])
 
   t.is(relaySockets.length, 2, 'both app connections share the relay transport sockets')
   t.is(clientNode._relayPool._connections.size, 1, 'client has one shared relay pool connection')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -5,6 +5,7 @@ const RelayServer = BlindRelay.Server
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
 const DHT = require('../')
 const Holepuncher = require('../lib/holepuncher')
+const NoiseWrap = require('../lib/noise-wrap')
 const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 
 test('relay connections through node, client side', async function (t) {
@@ -658,6 +659,78 @@ test('relay connections through same node reuse transport sockets', async functi
   await clientNode.destroy()
   await serverNode.destroy()
   await relayNode.destroy()
+})
+
+test('server cleans up duplicate pending relay tokens', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  let first = null
+
+  t.teardown(async function () {
+    if (first && first.relayTimeout) clearTimeout(first.relayTimeout)
+
+    await serverNode.destroy()
+    await relayNode.destroy()
+  })
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    // Keep the transport open without completing the blind-relay pairing.
+    socket.on('error', () => {})
+  })
+
+  await relayTransportServer.listen()
+
+  const token = BlindRelay.token()
+  const server = serverNode.createServer({
+    handshakeClearWait: 50,
+    shareLocalAddress: false
+  })
+
+  await server.listen()
+
+  const peerAddress = { host: '127.0.0.2', port: 49152 }
+  const req = {
+    to: serverNode.address(),
+    socket: serverNode.io.serverSocket
+  }
+
+  const attackerKeyPair = DHT.keyPair()
+  const payload = {
+    error: 0,
+    firewall: DHT.FIREWALL.CONSISTENT,
+    udx: { reusableSocket: false, id: 1, seq: 0 },
+    relayThrough: { publicKey: relayTransportServer.publicKey, token }
+  }
+  const createNoise = () => new NoiseWrap(attackerKeyPair, server.publicKey).send(payload)
+
+  await server._onpeerhandshake({ noise: await createNoise(), peerAddress }, req)
+  first = server._holepunches.find(Boolean)
+
+  t.ok(first && first.relayPairing, 'first relay pairing remains pending')
+
+  const secondNoise = await createNoise()
+  const secondAttempt = server._onpeerhandshake({ noise: secondNoise, peerAddress }, req)
+  const second = server._holepunches.find((handshake) => handshake && handshake !== first)
+  const secondKey = secondNoise.toString('hex')
+  const secondReply = await secondAttempt
+
+  t.is(secondReply, null, 'duplicate handshake has no reply')
+  t.ok(second, 'captured duplicate handshake state')
+  t.is(serverNode.stats.relaying.aborts, 1, 'duplicate relay pairing counts as aborted')
+
+  if ([...serverNode.rawStreams].includes(second.rawStream)) {
+    await once(second.rawStream, 'close')
+  }
+
+  await waitFor(() => !server._connects.has(secondKey))
+
+  t.absent(
+    [...serverNode.rawStreams].includes(second.rawStream),
+    'duplicate raw stream is released'
+  )
+  t.absent(server._holepunches.includes(second), 'duplicate handshake slot is cleared')
 })
 
 test('relay pool closes app streams when shared transports close', async function (t) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -823,8 +823,7 @@ test('relay pool unpairs if pairing aborts before remote pairs', async function 
   rawStream.destroy()
 
   await waitFor(() => relay._pairing.size === 0)
-  await waitFor(() => clientNode._relayPool._connections.size === 0)
-  t.is(relay._pairing.size, 0, 'pending half-pairing is unpaired')
+  t.pass('pending half-pairing is unpaired')
   t.is(clientNode._relayPool._connections.size, 0, 'relay pool closes after aborted pairing')
 
   await clientNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1044,8 +1044,8 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   const relaySocket = firstPairing.socket
   const relayConnection = firstPairing.connection
 
-  // Simulate direct upgrade for the first pairing, leaving its unpair delayed.
-  firstPairing.closePairing()
+  // Simulate direct upgrade for the first pairing with a shorter delayed unpair.
+  firstPairing._release(true, 1000)
   firstStream.destroy()
 
   t.is(relayConnection.pendingReleaseTimers.size, 1, 'first pairing schedules delayed unpair')
@@ -1061,6 +1061,7 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   t.is(secondPairing.socket, relaySocket, 'new pairing reuses the pending relay transport')
 
   await waitFor(() => relay._pairing.size === 2)
+  await waitFor(() => relay._pairing.size === 1)
   t.is(clientNode._relayPool._connections.size, 1, 'pool connection stays open for the new pairing')
   t.is(
     getOnlyRelayPoolConnection(clientNode).socket,

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -692,12 +692,10 @@ test('relay connections through same node reuse transport sockets', async functi
 
   const clientSockets = [
     clientNode.connect(appServer.publicKey, {
-      holepunch: false,
       localConnection: false,
       relayThrough: relayTransportServer.publicKey
     }),
     clientNode.connect(appServer.publicKey, {
-      holepunch: false,
       localConnection: false,
       relayThrough: relayTransportServer.publicKey
     })
@@ -744,7 +742,6 @@ test('relay connections through same node reuse transport sockets', async functi
 
   const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
-    holepunch: false,
     localConnection: false,
     relayThrough: relayTransportServer.publicKey
   })
@@ -826,12 +823,10 @@ test('relay pool closes app streams when shared transports close', async functio
 
   const clientSockets = [
     clientNode.connect(appServer.publicKey, {
-      holepunch: false,
       localConnection: false,
       relayThrough: relayTransportServer.publicKey
     }),
     clientNode.connect(appServer.publicKey, {
-      holepunch: false,
       localConnection: false,
       relayThrough: relayTransportServer.publicKey
     })
@@ -861,7 +856,6 @@ test('relay pool closes app streams when shared transports close', async functio
 
   const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
-    holepunch: false,
     localConnection: false,
     relayThrough: relayTransportServer.publicKey
   })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -216,9 +216,9 @@ async function waitFor(fn, timeout = 2000) {
 }
 
 function getOnlyRelayPoolConnection(node) {
-  const entries = [...node._relayPool._entries.values()]
-  if (entries.length !== 1) throw new Error('Expected exactly one relay pool connection')
-  return entries[0]
+  const connections = [...node._relayPool._connections.values()]
+  if (connections.length !== 1) throw new Error('Expected exactly one relay pool connection')
+  return connections[0]
 }
 
 function captureDelayedRelayUnpairTimer(t) {
@@ -831,8 +831,8 @@ test('relay pool closes app streams when shared transports close', async functio
     ...clientSockets.map((socket) => once(socket, 'open'))
   ])
 
-  t.is(clientNode._relayPool._entries.size, 1, 'client has one shared relay pool entry')
-  t.is(serverNode._relayPool._entries.size, 1, 'server has one shared relay pool entry')
+  t.is(clientNode._relayPool._connections.size, 1, 'client has one shared relay pool connection')
+  t.is(serverNode._relayPool._connections.size, 1, 'server has one shared relay pool connection')
 
   const closed = [
     ...clientSockets.map((socket) => once(socket, 'close')),
@@ -844,8 +844,8 @@ test('relay pool closes app streams when shared transports close', async functio
 
   await Promise.all(closed)
   t.pass('active app streams close when shared relay transports close')
-  t.is(clientNode._relayPool._entries.size, 0, 'client relay pool entry is removed')
-  t.is(serverNode._relayPool._entries.size, 0, 'server relay pool entry is removed')
+  t.is(clientNode._relayPool._connections.size, 0, 'client relay pool connection is removed')
+  t.is(serverNode._relayPool._connections.size, 0, 'server relay pool connection is removed')
 
   const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
@@ -906,9 +906,9 @@ test('relay pool unpairs if pairing aborts before remote pairs', async function 
   rawStream.destroy()
 
   await waitFor(() => relay._pairing.size === 0)
-  await waitFor(() => clientNode._relayPool._entries.size === 0)
+  await waitFor(() => clientNode._relayPool._connections.size === 0)
   t.is(relay._pairing.size, 0, 'pending half-pairing is unpaired')
-  t.is(clientNode._relayPool._entries.size, 0, 'relay pool closes after aborted pairing')
+  t.is(clientNode._relayPool._connections.size, 0, 'relay pool closes after aborted pairing')
 
   await clientNode.destroy()
   await relayNode.destroy()
@@ -944,7 +944,7 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   })
   const closingSocket = firstPairing.socket
 
-  // Simulate the close-event race where the pool entry still exists but its transport is closing.
+  // Simulate the close-event race where the pool connection still exists but its transport is closing.
   closingSocket.destroy()
 
   const secondStream = clientNode.createRawStream({ framed: true })
@@ -1008,13 +1008,13 @@ test('relay pool reuses transport and takes lowest relay keepalive', async funct
 
   t.is(secondPairing.socket, firstSocket, 'different keepalive values reuse transport')
   t.is(firstSocket.keepAlive, 1000, 'shared transport takes lower keepalive')
-  t.is(clientNode._relayPool._entries.size, 1, 'different keepalive values use one entry')
+  t.is(clientNode._relayPool._connections.size, 1, 'different keepalive values use one connection')
 
   const thirdPairing = pair(30000)
 
   t.is(thirdPairing.socket, firstSocket, 'higher keepalive value reuses transport')
   t.is(firstSocket.keepAlive, 1000, 'shared transport keeps lower keepalive')
-  t.is(clientNode._relayPool._entries.size, 1, 'higher keepalive value reuses existing entry')
+  t.is(clientNode._relayPool._connections.size, 1, 'higher keepalive value reuses existing connection')
 
   for (const { pairing, stream } of pairings) {
     pairing.release()
@@ -1128,7 +1128,7 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   delayedUnpair.fire()
 
   await waitFor(() => relay._pairing.size === 1)
-  t.is(clientNode._relayPool._entries.size, 1, 'pool entry stays open for the new pairing')
+  t.is(clientNode._relayPool._connections.size, 1, 'pool connection stays open for the new pairing')
   t.is(
     getOnlyRelayPoolConnection(clientNode).socket,
     relaySocket,
@@ -1140,7 +1140,7 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   secondStream.destroy()
 
   await waitFor(() => relay._pairing.size === 0)
-  await waitFor(() => clientNode._relayPool._entries.size === 0)
+  await waitFor(() => clientNode._relayPool._connections.size === 0)
 
   await clientNode.destroy()
   await relayNode.destroy()
@@ -1403,8 +1403,8 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
   await Promise.all([relaySocketsOpened, relayStreamsPaired])
 
   t.is(relaySockets.length, 2, 'both app connections share the relay transport sockets')
-  t.is(clientNode._relayPool._entries.size, 1, 'client has one shared relay pool entry')
-  t.is(serverNode._relayPool._entries.size, 1, 'server has one shared relay pool entry')
+  t.is(clientNode._relayPool._connections.size, 1, 'client has one shared relay pool connection')
+  t.is(serverNode._relayPool._connections.size, 1, 'server has one shared relay pool connection')
 
   const beforeUpgrade = once(relayOnlyClientSocket, 'data')
   relayOnlyClientSocket.write(Buffer.from('before direct upgrade'))

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -221,68 +221,6 @@ function getOnlyRelayPoolConnection(node) {
   return connections[0]
 }
 
-function captureDelayedRelayUnpairTimer(t) {
-  const setTimeoutOriginal = global.setTimeout
-  const clearTimeoutOriginal = global.clearTimeout
-  let captured = null
-  let unrefed = false
-  let cleared = false
-  let fired = false
-
-  global.setTimeout = function (fn, delay, ...args) {
-    const timer = setTimeoutOriginal.call(this, fn, delay, ...args)
-
-    if (delay !== 10000) return timer
-
-    captured = {
-      timer,
-      fire() {
-        if (fired) return
-        fired = true
-        clearTimeoutOriginal(timer)
-        return fn()
-      },
-      unref() {
-        unrefed = true
-        if (timer.unref) return timer.unref()
-      }
-    }
-
-    return captured
-  }
-
-  global.clearTimeout = function (timer) {
-    if (timer === captured) {
-      cleared = true
-      return clearTimeoutOriginal.call(this, captured.timer)
-    }
-
-    return clearTimeoutOriginal.call(this, timer)
-  }
-
-  t.teardown(function () {
-    global.setTimeout = setTimeoutOriginal
-    global.clearTimeout = clearTimeoutOriginal
-    if (captured !== null) clearTimeoutOriginal(captured.timer)
-  })
-
-  return {
-    fire() {
-      if (captured === null) throw new Error('Expected delayed relay unpair timer')
-      return captured.fire()
-    },
-    get captured() {
-      return captured !== null
-    },
-    get unrefed() {
-      return unrefed
-    },
-    get cleared() {
-      return cleared
-    }
-  }
-}
-
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -1056,18 +994,17 @@ test('relay pool unrefs and clears delayed direct-upgrade unpairs', async functi
 
   await waitFor(() => relay._pairing.size === 1)
 
-  // The direct-upgrade unpair delay is intentionally long, so wrap the timer to
-  // verify cleanup behavior without waiting for the delay to elapse.
-  const delayedUnpair = captureDelayedRelayUnpairTimer(t)
-
   // closePairing is the direct-upgrade cleanup path that schedules delayed unpair.
+  const connection = pairing.connection
   pairing.closePairing()
   rawStream.destroy()
 
-  t.ok(delayedUnpair.unrefed, 'delayed unpair timer is unrefed')
+  t.is(connection.pendingReleaseTimers.size, 1, 'delayed unpair timer is added')
+  const [timer] = connection.pendingReleaseTimers
+  t.absent(timer.hasRef(), 'delayed unpair timer is unrefed')
 
   await clientNode._relayPool.destroy()
-  t.ok(delayedUnpair.cleared, 'delayed unpair timer is cleared on pool destroy')
+  t.is(connection.pendingReleaseTimers.size, 0, 'delayed unpair timer is cleared on pool destroy')
 
   await clientNode.destroy()
   await relayNode.destroy()
@@ -1105,13 +1042,13 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   await waitFor(() => relay._pairing.size === 1)
 
   const relaySocket = firstPairing.socket
-  const delayedUnpair = captureDelayedRelayUnpairTimer(t)
+  const relayConnection = firstPairing.connection
 
   // Simulate direct upgrade for the first pairing, leaving its unpair delayed.
   firstPairing.closePairing()
   firstStream.destroy()
 
-  t.ok(delayedUnpair.captured, 'first pairing schedules delayed unpair')
+  t.is(relayConnection.pendingReleaseTimers.size, 1, 'first pairing schedules delayed unpair')
 
   const secondStream = clientNode.createRawStream({ framed: true })
   const secondPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
@@ -1124,10 +1061,6 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   t.is(secondPairing.socket, relaySocket, 'new pairing reuses the pending relay transport')
 
   await waitFor(() => relay._pairing.size === 2)
-
-  delayedUnpair.fire()
-
-  await waitFor(() => relay._pairing.size === 1)
   t.is(clientNode._relayPool._connections.size, 1, 'pool connection stays open for the new pairing')
   t.is(
     getOnlyRelayPoolConnection(clientNode).socket,
@@ -1139,7 +1072,7 @@ test('relay pool keeps transport open for pairings started during delayed unpair
   secondPairing.release()
   secondStream.destroy()
 
-  await waitFor(() => relay._pairing.size === 0)
+  await clientNode._relayPool.destroy()
   await waitFor(() => clientNode._relayPool._connections.size === 0)
 
   await clientNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -221,6 +221,68 @@ function getOnlyRelayPoolEntry(node) {
   return entries[0]
 }
 
+function captureDelayedRelayUnpairTimer(t) {
+  const setTimeoutOriginal = global.setTimeout
+  const clearTimeoutOriginal = global.clearTimeout
+  let captured = null
+  let unrefed = false
+  let cleared = false
+  let fired = false
+
+  global.setTimeout = function (fn, delay, ...args) {
+    const timer = setTimeoutOriginal.call(this, fn, delay, ...args)
+
+    if (delay !== 10000) return timer
+
+    captured = {
+      timer,
+      fire() {
+        if (fired) return
+        fired = true
+        clearTimeoutOriginal(timer)
+        return fn()
+      },
+      unref() {
+        unrefed = true
+        if (timer.unref) return timer.unref()
+      }
+    }
+
+    return captured
+  }
+
+  global.clearTimeout = function (timer) {
+    if (timer === captured) {
+      cleared = true
+      return clearTimeoutOriginal.call(this, captured.timer)
+    }
+
+    return clearTimeoutOriginal.call(this, timer)
+  }
+
+  t.teardown(function () {
+    global.setTimeout = setTimeoutOriginal
+    global.clearTimeout = clearTimeoutOriginal
+    if (captured !== null) clearTimeoutOriginal(captured.timer)
+  })
+
+  return {
+    fire() {
+      if (captured === null) throw new Error('Expected delayed relay unpair timer')
+      return captured.fire()
+    },
+    get captured() {
+      return captured !== null
+    },
+    get unrefed() {
+      return unrefed
+    },
+    get cleared() {
+      return cleared
+    }
+  }
+}
+
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -949,49 +1011,85 @@ test('relay pool unrefs and clears delayed direct-upgrade unpairs', async functi
 
   // The direct-upgrade unpair delay is intentionally long, so wrap the timer to
   // verify cleanup behavior without waiting for the delay to elapse.
-  const setTimeoutOriginal = global.setTimeout
-  const clearTimeoutOriginal = global.clearTimeout
-  let delayedTimer = null
-  let unrefed = false
-  let cleared = false
-
-  global.setTimeout = function (fn, delay, ...args) {
-    const timer = setTimeoutOriginal.call(this, fn, delay, ...args)
-
-    if (delay > 1000) {
-      delayedTimer = {
-        timer,
-        unref() {
-          unrefed = true
-          if (timer.unref) return timer.unref()
-        }
-      }
-
-      return delayedTimer
-    }
-
-    return timer
-  }
-
-  global.clearTimeout = function (timer) {
-    if (timer === delayedTimer) cleared = true
-    return clearTimeoutOriginal.call(this, timer === delayedTimer ? delayedTimer.timer : timer)
-  }
-
-  t.teardown(function () {
-    global.setTimeout = setTimeoutOriginal
-    global.clearTimeout = clearTimeoutOriginal
-    if (delayedTimer !== null) clearTimeoutOriginal(delayedTimer.timer)
-  })
+  const delayedUnpair = captureDelayedRelayUnpairTimer(t)
 
   // closePairing is the direct-upgrade cleanup path that schedules delayed unpair.
   pairing.closePairing()
   rawStream.destroy()
 
-  t.ok(unrefed, 'delayed unpair timer is unrefed')
+  t.ok(delayedUnpair.unrefed, 'delayed unpair timer is unrefed')
 
   await clientNode._relayPool.destroy()
-  t.ok(cleared, 'delayed unpair timer is cleared on pool destroy')
+  t.ok(delayedUnpair.cleared, 'delayed unpair timer is cleared on pool destroy')
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
+test('relay pool keeps transport open for pairings started during delayed unpair', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const firstStream = clientNode.createRawStream({ framed: true })
+  const firstPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: firstStream,
+    keepAlive: 5000
+  })
+
+  await waitFor(() => relay._pairing.size === 1)
+
+  const relaySocket = firstPairing.socket
+  const delayedUnpair = captureDelayedRelayUnpairTimer(t)
+
+  // Simulate direct upgrade for the first pairing, leaving its unpair delayed.
+  firstPairing.closePairing()
+  firstStream.destroy()
+
+  t.ok(delayedUnpair.captured, 'first pairing schedules delayed unpair')
+
+  const secondStream = clientNode.createRawStream({ framed: true })
+  const secondPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: secondStream,
+    keepAlive: 5000
+  })
+
+  t.is(secondPairing.socket, relaySocket, 'new pairing reuses the pending relay transport')
+
+  await waitFor(() => relay._pairing.size === 2)
+
+  delayedUnpair.fire()
+
+  await waitFor(() => relay._pairing.size === 1)
+  t.is(clientNode._relayPool._entries.size, 1, 'pool entry stays open for the new pairing')
+  t.is(getOnlyRelayPoolEntry(clientNode).socket, relaySocket, 'same relay transport remains pooled')
+  t.absent(relaySocket.destroying, 'relay transport is not closing')
+
+  secondPairing.release()
+  secondStream.destroy()
+
+  await waitFor(() => relay._pairing.size === 0)
+  await waitFor(() => clientNode._relayPool._entries.size === 0)
 
   await clientNode.destroy()
   await relayNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -965,7 +965,7 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   await relayNode.destroy()
 })
 
-test('relay pool keys transport reuse by relay keepalive', async function (t) {
+test('relay pool reuses transport and takes lowest relay keepalive', async function (t) {
   const { bootstrap } = await swarm(t)
 
   const relayNode = createDHT({ bootstrap })
@@ -1001,20 +1001,20 @@ test('relay pool keys transport reuse by relay keepalive', async function (t) {
     return pairing
   }
 
-  const firstPairing = pair(1000)
+  const firstPairing = pair(30000)
   const firstSocket = firstPairing.socket
 
-  const secondPairing = pair(30000)
+  const secondPairing = pair(1000)
 
-  t.not(secondPairing.socket, firstSocket, 'different keepalive values do not share transport')
-  t.is(firstSocket.keepAlive, 1000, 'existing transport keepalive is preserved')
-  t.is(secondPairing.socket.keepAlive, 30000, 'new transport uses its requested keepalive')
-  t.is(clientNode._relayPool._entries.size, 2, 'different keepalive values use separate entries')
+  t.is(secondPairing.socket, firstSocket, 'different keepalive values reuse transport')
+  t.is(firstSocket.keepAlive, 1000, 'shared transport takes lower keepalive')
+  t.is(clientNode._relayPool._entries.size, 1, 'different keepalive values use one entry')
 
-  const thirdPairing = pair(1000)
+  const thirdPairing = pair(30000)
 
-  t.is(thirdPairing.socket, firstSocket, 'same keepalive value reuses transport')
-  t.is(clientNode._relayPool._entries.size, 2, 'same keepalive value reuses existing entry')
+  t.is(thirdPairing.socket, firstSocket, 'higher keepalive value reuses transport')
+  t.is(firstSocket.keepAlive, 1000, 'shared transport keeps lower keepalive')
+  t.is(clientNode._relayPool._entries.size, 1, 'higher keepalive value reuses existing entry')
 
   for (const { pairing, stream } of pairings) {
     pairing.release()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -843,6 +843,66 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   await relayNode.destroy()
 })
 
+test('relay pool destroys non-reusable transport before replacing it', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const firstStream = clientNode.createRawStream({ framed: true })
+  const firstPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: firstStream,
+    keepAlive: 5000
+  })
+  const firstConnection = firstPairing.connection
+  const firstSocket = firstPairing.socket
+
+  await waitFor(() => relay._pairing.size === 1)
+
+  const firstClientClosed = once(firstConnection.client, 'close')
+  firstConnection.client.destroy()
+  await firstClientClosed
+
+  t.ok(firstConnection.client.closed, 'first relay client is closed')
+  t.absent(firstSocket.destroyed, 'first relay transport is still open')
+  t.absent(firstSocket.destroying, 'first relay transport is not already closing')
+
+  const secondStream = clientNode.createRawStream({ framed: true })
+  const secondPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: secondStream,
+    keepAlive: 5000
+  })
+
+  t.not(secondPairing.socket, firstSocket, 'new pairing gets a fresh relay transport')
+  t.ok(firstConnection.destroyed, 'replaced relay pool connection is destroyed')
+  t.ok(firstSocket.destroyed || firstSocket.destroying, 'replaced relay transport is closing')
+
+  await waitFor(() => firstSocket.destroyed)
+  t.is(clientNode._relayPool._connections.size, 1, 'only fresh relay pool connection remains')
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
 test('relay pool reuses transport and takes lowest relay keepalive', async function (t) {
   const { bootstrap } = await swarm(t)
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -903,6 +903,62 @@ test('relay pool destroys non-reusable transport before replacing it', async fun
   await relayNode.destroy()
 })
 
+test('relay pool connection destroy waits for close if transport errors', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const rawStream = clientNode.createRawStream({ framed: true })
+  const pairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: rawStream,
+    keepAlive: 5000
+  })
+
+  await waitFor(() => relay._pairing.size === 1)
+
+  const connection = pairing.connection
+  const socket = connection.socket
+  let closed = false
+
+  socket.once('close', () => {
+    closed = true
+  })
+
+  const destroy = socket.destroy.bind(socket)
+  socket.destroy = function (...args) {
+    socket.destroy = destroy
+    socket.emit('error', new Error('synthetic destroy error'))
+    setTimeout(() => destroy(...args), 50)
+    return socket
+  }
+
+  await t.execution(connection.destroy(), 'destroy ignores transport error while waiting for close')
+  t.ok(closed, 'destroy resolves after transport closes')
+  t.ok(socket.destroyed, 'transport is destroyed')
+
+  rawStream.destroy()
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
 test('relay pool reuses transport and takes lowest relay keepalive', async function (t) {
   const { bootstrap } = await swarm(t)
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -972,6 +972,66 @@ test('relay pool does not reuse closing transport sockets', async function (t) {
   await relayNode.destroy()
 })
 
+test('relay pool keys transport reuse by relay keepalive', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const pairings = []
+
+  function pair(keepAlive) {
+    const stream = clientNode.createRawStream({ framed: true })
+    const pairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+      isInitiator: true,
+      token: BlindRelay.token(),
+      stream,
+      keepAlive
+    })
+
+    pairings.push({ pairing, stream })
+    return pairing
+  }
+
+  const firstPairing = pair(1000)
+  const firstSocket = firstPairing.socket
+
+  const secondPairing = pair(30000)
+
+  t.not(secondPairing.socket, firstSocket, 'different keepalive values do not share transport')
+  t.is(firstSocket.keepAlive, 1000, 'existing transport keepalive is preserved')
+  t.is(secondPairing.socket.keepAlive, 30000, 'new transport uses its requested keepalive')
+  t.is(clientNode._relayPool._entries.size, 2, 'different keepalive values use separate entries')
+
+  const thirdPairing = pair(1000)
+
+  t.is(thirdPairing.socket, firstSocket, 'same keepalive value reuses transport')
+  t.is(clientNode._relayPool._entries.size, 2, 'same keepalive value reuses existing entry')
+
+  for (const { pairing, stream } of pairings) {
+    pairing.release()
+    stream.destroy()
+  }
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
 test('relay pool unrefs and clears delayed direct-upgrade unpairs', async function (t) {
   const { bootstrap } = await swarm(t)
 

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -902,8 +902,6 @@ test('relay pool reuses transport and takes lowest relay keepalive', async funct
 
   await relayTransportServer.listen()
 
-  const pairings = []
-
   function pair(keepAlive) {
     const stream = clientNode.createRawStream({ framed: true })
     const pairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
@@ -913,7 +911,6 @@ test('relay pool reuses transport and takes lowest relay keepalive', async funct
       keepAlive
     })
 
-    pairings.push({ pairing, stream })
     return pairing
   }
 
@@ -935,11 +932,6 @@ test('relay pool reuses transport and takes lowest relay keepalive', async funct
     1,
     'higher keepalive value reuses existing connection'
   )
-
-  for (const { pairing, stream } of pairings) {
-    pairing.release()
-    stream.destroy()
-  }
 
   await clientNode.destroy()
   await relayNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -865,6 +865,56 @@ test('relay pool unpairs if pairing aborts before remote pairs', async function 
   await relayNode.destroy()
 })
 
+test('relay pool does not reuse closing transport sockets', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close())
+
+  const relayTransportServer = relayNode.createServer(function (socket) {
+    const session = relay.accept(socket, { id: socket.remotePublicKey })
+    session.on('error', (err) => t.comment(err.message))
+  })
+
+  await relayTransportServer.listen()
+
+  const firstStream = clientNode.createRawStream({ framed: true })
+  const firstPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: firstStream,
+    keepAlive: 5000
+  })
+  const closingSocket = firstPairing.socket
+
+  closingSocket.destroy()
+
+  const secondStream = clientNode.createRawStream({ framed: true })
+  const secondPairing = clientNode._relayPool.pair(relayTransportServer.publicKey, {
+    isInitiator: true,
+    token: BlindRelay.token(),
+    stream: secondStream,
+    keepAlive: 5000
+  })
+
+  t.not(secondPairing.socket, closingSocket, 'new pairing gets a fresh relay transport')
+
+  firstStream.destroy()
+  secondStream.destroy()
+  secondPairing.release()
+
+  await clientNode.destroy()
+  await relayNode.destroy()
+})
+
 test('relay connection upgrades to direct connection', async function (t) {
   for (const opts of [
     { name: 'default keepalive' },
@@ -1147,7 +1197,7 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
 
   resumePunching()
   await Promise.all([clientUpgraded, serverUpgraded])
-  await waitFor(() => closedRelayStreams === 2)
+  await waitFor(() => closedRelayStreams === 2, 12000)
 
   t.is(closedRelayStreams, 2, 'direct upgrade releases only its relay pairing')
   t.is(closedRelaySockets, 0, 'shared relay transports stay open for the other pairing')
@@ -1186,7 +1236,7 @@ test('direct upgrade keeps other pooled relay pairings alive', async function (t
   await endAndCloseSocket(relayOnlyClientSocket)
   if (!relayOnlyServerSocket.destroyed) await once(relayOnlyServerSocket, 'close')
 
-  await waitFor(() => closedRelaySockets === 2)
+  await waitFor(() => closedRelaySockets === 2, 12000)
   t.is(closedRelaySockets, 2, 'shared relay transports close after remaining pairing closes')
 
   await relayNode.destroy()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -215,9 +215,9 @@ async function waitFor(fn, timeout = 2000) {
   }
 }
 
-function getOnlyRelayPoolEntry(node) {
+function getOnlyRelayPoolConnection(node) {
   const entries = [...node._relayPool._entries.values()]
-  if (entries.length !== 1) throw new Error('Expected exactly one relay pool entry')
+  if (entries.length !== 1) throw new Error('Expected exactly one relay pool connection')
   return entries[0]
 }
 
@@ -846,8 +846,8 @@ test('relay pool closes app streams when shared transports close', async functio
     ...serverSockets.map((socket) => once(socket, 'close'))
   ]
 
-  getOnlyRelayPoolEntry(clientNode).socket.destroy()
-  getOnlyRelayPoolEntry(serverNode).socket.destroy()
+  getOnlyRelayPoolConnection(clientNode).socket.destroy()
+  getOnlyRelayPoolConnection(serverNode).socket.destroy()
 
   await Promise.all(closed)
   t.pass('active app streams close when shared relay transports close')
@@ -1136,7 +1136,11 @@ test('relay pool keeps transport open for pairings started during delayed unpair
 
   await waitFor(() => relay._pairing.size === 1)
   t.is(clientNode._relayPool._entries.size, 1, 'pool entry stays open for the new pairing')
-  t.is(getOnlyRelayPoolEntry(clientNode).socket, relaySocket, 'same relay transport remains pooled')
+  t.is(
+    getOnlyRelayPoolConnection(clientNode).socket,
+    relaySocket,
+    'same relay transport remains pooled'
+  )
   t.absent(relaySocket.destroying, 'relay transport is not closing')
 
   secondPairing.release()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -952,7 +952,11 @@ test('relay pool reuses transport and takes lowest relay keepalive', async funct
 
   t.is(thirdPairing.socket, firstSocket, 'higher keepalive value reuses transport')
   t.is(firstSocket.keepAlive, 1000, 'shared transport keeps lower keepalive')
-  t.is(clientNode._relayPool._connections.size, 1, 'higher keepalive value reuses existing connection')
+  t.is(
+    clientNode._relayPool._connections.size,
+    1,
+    'higher keepalive value reuses existing connection'
+  )
 
   for (const { pairing, stream } of pairings) {
     pairing.release()

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -625,11 +625,9 @@ test('relay connections through same node reuse transport sockets', async functi
     resolveRelaySockets = resolve
   })
 
-  const serverSockets = []
-  let resolveServerSockets = null
-  const serverSocketsOpened = new Promise((resolve) => {
-    resolveServerSockets = resolve
-  })
+  let firstServerSocket = null
+  let secondServerSocket = null
+  let reconnectedServerSocket = null
 
   const relay = new RelayServer({
     createStream(opts) {
@@ -680,8 +678,9 @@ test('relay connections through same node reuse transport sockets', async functi
       relayThrough: relayTransportServer.publicKey
     },
     function (socket) {
-      serverSockets.push(socket)
-      if (serverSockets.length === 2) resolveServerSockets()
+      if (firstServerSocket === null) firstServerSocket = socket
+      else if (secondServerSocket === null) secondServerSocket = socket
+      else reconnectedServerSocket = socket
 
       socket.on('data', (data) => socket.write(data))
       socket.on('end', () => socket.end())
@@ -690,77 +689,71 @@ test('relay connections through same node reuse transport sockets', async functi
 
   await appServer.listen()
 
-  const clientSockets = [
-    clientNode.connect(appServer.publicKey, {
-      localConnection: false,
-      relayThrough: relayTransportServer.publicKey
-    }),
-    clientNode.connect(appServer.publicKey, {
-      localConnection: false,
-      relayThrough: relayTransportServer.publicKey
-    })
-  ]
+  const firstClientSocket = clientNode.connect(appServer.publicKey, {
+    localConnection: false,
+    relayThrough: relayTransportServer.publicKey
+  })
+  await once(firstClientSocket, 'open')
 
-  await Promise.all([
-    relaySocketsOpened,
-    relayStreamsPaired,
-    serverSocketsOpened,
-    ...clientSockets.map((socket) => once(socket, 'open'))
-  ])
+  const secondClientSocket = clientNode.connect(appServer.publicKey, {
+    localConnection: false,
+    relayThrough: relayTransportServer.publicKey
+  })
+  await once(secondClientSocket, 'open')
+
+  await Promise.all([relaySocketsOpened, relayStreamsPaired])
 
   t.is(relaySockets.length, 2, 'both peers reuse one transport socket to the relay')
 
-  const replies = clientSockets.map((socket) => once(socket, 'data'))
-  clientSockets[0].write(Buffer.from('hello 1'))
-  clientSockets[1].write(Buffer.from('hello 2'))
+  const firstReply = once(firstClientSocket, 'data')
+  const secondReply = once(secondClientSocket, 'data')
+  firstClientSocket.write(Buffer.from('hello 1'))
+  secondClientSocket.write(Buffer.from('hello 2'))
 
-  t.alike((await replies[0])[0], Buffer.from('hello 1'), 'first relayed connection carries data')
-  t.alike((await replies[1])[0], Buffer.from('hello 2'), 'second relayed connection carries data')
+  t.alike(await firstReply, [Buffer.from('hello 1')], 'first relayed connection carries data')
+  t.alike(await secondReply, [Buffer.from('hello 2')], 'second relayed connection carries data')
 
-  const firstServerClosed = Promise.race(serverSockets.map((socket) => once(socket, 'close')))
-  await endAndCloseSocket(clientSockets[0])
+  const firstServerClosed = once(firstServerSocket, 'close')
+  await endAndCloseSocket(firstClientSocket)
   await firstServerClosed
   await firstPairingReleased
   t.is(closedRelayStreams, 2, 'closing one app connection releases only its relay pairing')
 
-  const secondReply = once(clientSockets[1], 'data')
-  clientSockets[1].write(Buffer.from('still relayed'))
+  const afterFirstClosedReply = once(secondClientSocket, 'data')
+  secondClientSocket.write(Buffer.from('still relayed'))
   t.alike(
-    (await secondReply)[0],
-    Buffer.from('still relayed'),
+    await afterFirstClosedReply,
+    [Buffer.from('still relayed')],
     'second relayed connection stays usable after first closes'
   )
 
-  await endAndCloseSocket(clientSockets[1])
+  await endAndCloseSocket(secondClientSocket)
 
-  for (const socket of serverSockets) {
-    if (!socket.destroyed) await once(socket, 'close')
-  }
+  if (!secondServerSocket.destroyed) await once(secondServerSocket, 'close')
 
   await waitFor(() => closedRelaySockets === 2)
   t.is(closedRelaySockets, 2, 'shared relay transports close after all pairings close')
 
-  const reconnectedServerSocket = waitFor(() => serverSockets.length === 3)
+  const reconnectedServerSocketOpened = waitFor(() => reconnectedServerSocket !== null)
   const reconnectedClientSocket = clientNode.connect(appServer.publicKey, {
     localConnection: false,
     relayThrough: relayTransportServer.publicKey
   })
 
-  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocket])
+  await Promise.all([once(reconnectedClientSocket, 'open'), reconnectedServerSocketOpened])
   await waitFor(() => relaySockets.length === 4)
   t.is(relaySockets.length, 4, 'reconnect creates fresh relay transport sockets')
 
   const reconnectedReply = once(reconnectedClientSocket, 'data')
   reconnectedClientSocket.write(Buffer.from('reconnected'))
   t.alike(
-    (await reconnectedReply)[0],
-    Buffer.from('reconnected'),
+    await reconnectedReply,
+    [Buffer.from('reconnected')],
     'reconnected relay path carries data'
   )
 
   await endAndCloseSocket(reconnectedClientSocket)
-  const lastServerSocket = serverSockets[serverSockets.length - 1]
-  if (!lastServerSocket.destroyed) await once(lastServerSocket, 'close')
+  if (!reconnectedServerSocket.destroyed) await once(reconnectedServerSocket, 'close')
 
   await clientNode.destroy()
   await serverNode.destroy()


### PR DESCRIPTION
Previously, each relayed app connection opened its own HyperDHT connection to the same relay. Multiple relayed connections through one relay therefore created duplicate relay transport sockets and extra keepalive/session overhead.

This adds an internal relay pool keyed by relay public key. Relay pairings now reuse one relay transport connection when possible, while each app connection still gets its own blind-relay pairing/raw stream.

Adds coverage for two simultaneous relayed app connections through the same relay. Previously this opened four relay transport sockets: client-to-relay and server-to-relay for each app connection. With reuse, the client and server each keep one relay transport socket, and the two app connections are represented as separate blind-relay pairings over those shared sockets.




### Context 


There are already two related reuse mechanisms, but neither owns blind-relay pairings:

- `ConnectionPool` reuses app-level HyperDHT connections keyed by remote public key. It returns an existing encrypted app stream and handles duplicate app connections.
- `_socketPool` / `reusableSocket` reuses lower-level UDX socket routes.

Relay reuse needs different lifecycle semantics. The shared object is the HyperDHT transport connection to the relay, but each app connection still needs its own blind-relay pairing/token/raw stream. When one app connection upgrades to direct or closes, we must release only that pairing, not destroy the shared relay transport if another pairing is still active.

This PR adds a small internal `RelayPool` for that relay-specific ownership model.


## Notes

### Unpairing delay

When a relayed app connection upgrades to direct, this PR releases only that relay pairing and keeps the shared relay transport open for any other active pairings.

The unpair is delayed because `remote-changed` is only a local signal. It means this side moved its raw stream to the direct path, but it does not prove the peer has also finished switching direct. Sending `unpair` immediately can tear down the relay leg while the peer still needs it, which showed up as a timeout in the direct-upgrade regression test.

The delay is a pragmatic, non-protocol-changing guard. A longer delay is safer for the upgrade race but keeps relay resources around longer after direct upgrade. A future protocol-level improvement could replace this with an explicit “both sides are direct” release signal before unpairing.

### Race Coverage

This is the tricky part of this PR since we re-using relay connection naturally creates a large flake surface around lifecycle mangement.

This PR includes coverage for the relay-pool cases most likely to regress:

- avoids reusing a relay transport after it has started closing
- keeps active relay pairings alive when another pairing upgrades to direct
- clears/unrefs delayed direct-upgrade unpair timers on pool destroy
- keeps the shared relay transport open when a new pairing starts during another pairing’s delayed unpair window



Disclaimer: PR was co-written with AI.
