### PR TITLE
Bump `compact-encoding` to `3.0.0`

### DIFF
--- a/lib/messages.js
+++ b/lib/messages.js
@@ -425,20 +425,31 @@ exports.pluginRequest = {
     c.string.preencode(state, m.plugin)
     c.uint.preencode(state, m.version)
     c.uint.preencode(state, m.command)
-    c.buffer.preencode(state, m.value)
+    state.end++ // max flag is 1 so always one byte
+
+    if (m.value) c.buffer.preencode(state, m.value)
   },
   encode(state, m) {
+    const flags = m.value ? 1 : 0
+
     c.string.encode(state, m.plugin)
     c.uint.encode(state, m.version)
     c.uint.encode(state, m.command)
-    c.buffer.encode(state, m.value)
+    c.uint.encode(state, flags)
+
+    if (m.value) c.buffer.encode(state, m.value)
   },
   decode(state) {
+    const r0 = c.string.decode(state)
+    const r1 = c.uint.decode(state)
+    const r2 = c.uint.decode(state)
+    const flags = c.uint.decode(state)
+
     return {
-      plugin: c.string.decode(state),
-      version: c.uint.decode(state),
-      command: c.uint.decode(state),
-      value: c.buffer.decode(state)
+      plugin: r0,
+      version: r1,
+      command: r2,
+      value: (flags & 1) !== 0 ? c.buffer.decode(state) : null
     }
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -425,20 +425,20 @@ exports.pluginRequest = {
     c.string.preencode(state, m.plugin)
     c.uint.preencode(state, m.version)
     c.uint.preencode(state, m.command)
-    c.optionalBuffer.preencode(state, m.value)
+    c.buffer.preencode(state, m.value)
   },
   encode(state, m) {
     c.string.encode(state, m.plugin)
     c.uint.encode(state, m.version)
     c.uint.encode(state, m.command)
-    c.optionalBuffer.encode(state, m.value)
+    c.buffer.encode(state, m.value)
   },
   decode(state) {
     return {
       plugin: c.string.decode(state),
       version: c.uint.decode(state),
       command: c.uint.decode(state),
-      value: c.optionalBuffer.decode(state)
+      value: c.buffer.decode(state)
     }
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -29,14 +29,14 @@ const ipv6Array = c.array(ipv6)
 exports.handshake = {
   preencode(state, m) {
     state.end += 1 + 1 + (m.peerAddress ? 6 : 0) + (m.relayAddress ? 6 : 0)
-    c.buffer.preencode(state, m.noise)
+    c.optionalBuffer.preencode(state, m.noise)
   },
   encode(state, m) {
     const flags = (m.peerAddress ? 1 : 0) | (m.relayAddress ? 2 : 0)
 
     c.uint.encode(state, flags)
     c.uint.encode(state, m.mode)
-    c.buffer.encode(state, m.noise)
+    c.optionalBuffer.encode(state, m.noise)
 
     if (m.peerAddress) ipv4.encode(state, m.peerAddress)
     if (m.relayAddress) ipv4.encode(state, m.relayAddress)
@@ -46,7 +46,7 @@ exports.handshake = {
 
     return {
       mode: c.uint.decode(state),
-      noise: c.buffer.decode(state),
+      noise: c.optionalBuffer.decode(state),
       peerAddress: flags & 1 ? ipv4.decode(state) : null,
       relayAddress: flags & 2 ? ipv4.decode(state) : null
     }
@@ -228,7 +228,7 @@ exports.holepunch = {
   preencode(state, m) {
     state.end += 2
     c.uint.preencode(state, m.id)
-    c.buffer.preencode(state, m.payload)
+    c.optionalBuffer.preencode(state, m.payload)
     if (m.peerAddress) ipv4.preencode(state, m.peerAddress)
   },
   encode(state, m) {
@@ -236,7 +236,7 @@ exports.holepunch = {
     c.uint.encode(state, flags)
     c.uint.encode(state, m.mode)
     c.uint.encode(state, m.id)
-    c.buffer.encode(state, m.payload)
+    c.optionalBuffer.encode(state, m.payload)
     if (m.peerAddress) ipv4.encode(state, m.peerAddress)
   },
   decode(state) {
@@ -244,7 +244,7 @@ exports.holepunch = {
     return {
       mode: c.uint.decode(state),
       id: c.uint.decode(state),
-      payload: c.buffer.decode(state),
+      payload: c.optionalBuffer.decode(state),
       peerAddress: flags & 1 ? ipv4.decode(state) : null
     }
   }
@@ -363,16 +363,16 @@ exports.announce = {
 exports.mutableSignable = {
   preencode(state, m) {
     c.uint.preencode(state, m.seq)
-    c.buffer.preencode(state, m.value)
+    c.optionalBuffer.preencode(state, m.value)
   },
   encode(state, m) {
     c.uint.encode(state, m.seq)
-    c.buffer.encode(state, m.value)
+    c.optionalBuffer.encode(state, m.value)
   },
   decode(state) {
     return {
       seq: c.uint.decode(state),
-      value: c.buffer.decode(state)
+      value: c.optionalBuffer.decode(state)
     }
   }
 }
@@ -381,20 +381,20 @@ exports.mutablePutRequest = {
   preencode(state, m) {
     c.fixed32.preencode(state, m.publicKey)
     c.uint.preencode(state, m.seq)
-    c.buffer.preencode(state, m.value)
+    c.optionalBuffer.preencode(state, m.value)
     c.fixed64.preencode(state, m.signature)
   },
   encode(state, m) {
     c.fixed32.encode(state, m.publicKey)
     c.uint.encode(state, m.seq)
-    c.buffer.encode(state, m.value)
+    c.optionalBuffer.encode(state, m.value)
     c.fixed64.encode(state, m.signature)
   },
   decode(state) {
     return {
       publicKey: c.fixed32.decode(state),
       seq: c.uint.decode(state),
-      value: c.buffer.decode(state),
+      value: c.optionalBuffer.decode(state),
       signature: c.fixed64.decode(state)
     }
   }
@@ -403,18 +403,18 @@ exports.mutablePutRequest = {
 exports.mutableGetResponse = {
   preencode(state, m) {
     c.uint.preencode(state, m.seq)
-    c.buffer.preencode(state, m.value)
+    c.optionalBuffer.preencode(state, m.value)
     c.fixed64.preencode(state, m.signature)
   },
   encode(state, m) {
     c.uint.encode(state, m.seq)
-    c.buffer.encode(state, m.value)
+    c.optionalBuffer.encode(state, m.value)
     c.fixed64.encode(state, m.signature)
   },
   decode(state) {
     return {
       seq: c.uint.decode(state),
-      value: c.buffer.decode(state),
+      value: c.optionalBuffer.decode(state),
       signature: c.fixed64.decode(state)
     }
   }
@@ -425,20 +425,20 @@ exports.pluginRequest = {
     c.string.preencode(state, m.plugin)
     c.uint.preencode(state, m.version)
     c.uint.preencode(state, m.command)
-    c.buffer.preencode(state, m.value)
+    c.optionalBuffer.preencode(state, m.value)
   },
   encode(state, m) {
     c.string.encode(state, m.plugin)
     c.uint.encode(state, m.version)
     c.uint.encode(state, m.command)
-    c.buffer.encode(state, m.value)
+    c.optionalBuffer.encode(state, m.value)
   },
   decode(state) {
     return {
       plugin: c.string.decode(state),
       version: c.uint.decode(state),
       command: c.uint.decode(state),
-      value: c.buffer.decode(state)
+      value: c.optionalBuffer.decode(state)
     }
   }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -29,14 +29,14 @@ const ipv6Array = c.array(ipv6)
 exports.handshake = {
   preencode(state, m) {
     state.end += 1 + 1 + (m.peerAddress ? 6 : 0) + (m.relayAddress ? 6 : 0)
-    c.optionalBuffer.preencode(state, m.noise)
+    c.buffer.preencode(state, m.noise)
   },
   encode(state, m) {
     const flags = (m.peerAddress ? 1 : 0) | (m.relayAddress ? 2 : 0)
 
     c.uint.encode(state, flags)
     c.uint.encode(state, m.mode)
-    c.optionalBuffer.encode(state, m.noise)
+    c.buffer.encode(state, m.noise)
 
     if (m.peerAddress) ipv4.encode(state, m.peerAddress)
     if (m.relayAddress) ipv4.encode(state, m.relayAddress)
@@ -46,7 +46,7 @@ exports.handshake = {
 
     return {
       mode: c.uint.decode(state),
-      noise: c.optionalBuffer.decode(state),
+      noise: c.buffer.decode(state),
       peerAddress: flags & 1 ? ipv4.decode(state) : null,
       relayAddress: flags & 2 ? ipv4.decode(state) : null
     }
@@ -228,7 +228,7 @@ exports.holepunch = {
   preencode(state, m) {
     state.end += 2
     c.uint.preencode(state, m.id)
-    c.optionalBuffer.preencode(state, m.payload)
+    c.buffer.preencode(state, m.payload)
     if (m.peerAddress) ipv4.preencode(state, m.peerAddress)
   },
   encode(state, m) {
@@ -236,7 +236,7 @@ exports.holepunch = {
     c.uint.encode(state, flags)
     c.uint.encode(state, m.mode)
     c.uint.encode(state, m.id)
-    c.optionalBuffer.encode(state, m.payload)
+    c.buffer.encode(state, m.payload)
     if (m.peerAddress) ipv4.encode(state, m.peerAddress)
   },
   decode(state) {
@@ -244,7 +244,7 @@ exports.holepunch = {
     return {
       mode: c.uint.decode(state),
       id: c.uint.decode(state),
-      payload: c.optionalBuffer.decode(state),
+      payload: c.buffer.decode(state),
       peerAddress: flags & 1 ? ipv4.decode(state) : null
     }
   }
@@ -363,16 +363,16 @@ exports.announce = {
 exports.mutableSignable = {
   preencode(state, m) {
     c.uint.preencode(state, m.seq)
-    c.optionalBuffer.preencode(state, m.value)
+    c.buffer.preencode(state, m.value)
   },
   encode(state, m) {
     c.uint.encode(state, m.seq)
-    c.optionalBuffer.encode(state, m.value)
+    c.buffer.encode(state, m.value)
   },
   decode(state) {
     return {
       seq: c.uint.decode(state),
-      value: c.optionalBuffer.decode(state)
+      value: c.buffer.decode(state)
     }
   }
 }
@@ -381,20 +381,20 @@ exports.mutablePutRequest = {
   preencode(state, m) {
     c.fixed32.preencode(state, m.publicKey)
     c.uint.preencode(state, m.seq)
-    c.optionalBuffer.preencode(state, m.value)
+    c.buffer.preencode(state, m.value)
     c.fixed64.preencode(state, m.signature)
   },
   encode(state, m) {
     c.fixed32.encode(state, m.publicKey)
     c.uint.encode(state, m.seq)
-    c.optionalBuffer.encode(state, m.value)
+    c.buffer.encode(state, m.value)
     c.fixed64.encode(state, m.signature)
   },
   decode(state) {
     return {
       publicKey: c.fixed32.decode(state),
       seq: c.uint.decode(state),
-      value: c.optionalBuffer.decode(state),
+      value: c.buffer.decode(state),
       signature: c.fixed64.decode(state)
     }
   }
@@ -403,18 +403,18 @@ exports.mutablePutRequest = {
 exports.mutableGetResponse = {
   preencode(state, m) {
     c.uint.preencode(state, m.seq)
-    c.optionalBuffer.preencode(state, m.value)
+    c.buffer.preencode(state, m.value)
     c.fixed64.preencode(state, m.signature)
   },
   encode(state, m) {
     c.uint.encode(state, m.seq)
-    c.optionalBuffer.encode(state, m.value)
+    c.buffer.encode(state, m.value)
     c.fixed64.encode(state, m.signature)
   },
   decode(state) {
     return {
       seq: c.uint.decode(state),
-      value: c.optionalBuffer.decode(state),
+      value: c.buffer.decode(state),
       signature: c.fixed64.decode(state)
     }
   }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "bare-events": "^2.2.0",
     "blind-relay": "^1.3.0",
     "bogon": "^1.0.0",
-    "compact-encoding": "^2.4.1",
+    "compact-encoding": "^3.0.0",
     "dht-rpc": "^6.15.1",
     "hypercore-crypto": "^3.3.0",
     "hypercore-id-encoding": "^1.2.0",


### PR DESCRIPTION
For the encoding using `compact-encoding` all `c.buffer` were converted to `c.optionalBuffer`.

Depends on:

- https://github.com/holepunchto/hypercore-crypto/pull/25
- https://github.com/holepunchto/hyperdht-address/pull/2
- https://github.com/holepunchto/dht-rpc/pull/127
- https://github.com/mafintosh/bogon/pull/5
- https://github.com/holepunchto/blind-relay/pull/16