### PR TITLE
Avoid reusing closing socket pool routes

### DIFF
--- a/lib/socket-pool.js
+++ b/lib/socket-pool.js
@@ -79,6 +79,11 @@ class SocketRoutes {
 
     let route = this._routes.get(id)
 
+    if (route && route.socket.closing) {
+      route.gc()
+      route = null
+    }
+
     if (!route) {
       const gc = () => {
         if (this._routes.get(id) === route) this._routes.delete(id)

--- a/lib/socket-pool.js
+++ b/lib/socket-pool.js
@@ -66,6 +66,10 @@ class SocketRoutes {
     const id = b4a.toString(publicKey, 'hex')
     const route = this._routes.get(id)
     if (!route) return null
+    if (route.socket.closing) {
+      route.gc()
+      return null
+    }
     return route
   }
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -117,22 +117,20 @@ function noop() {}
 
 test('socket pool ignores closing reusable routes', async function (t) {
   const node = createDHT({ bootstrap: [], ephemeral: true })
+  const routes = node._socketPool.routes
   const publicKey = Buffer.alloc(32, 1)
 
   const socket = new EventEmitter()
-  socket.closing = false
 
   const rawStream = new EventEmitter()
   rawStream.socket = socket
-  rawStream.remoteHost = '127.0.0.1'
-  rawStream.remotePort = 1234
 
-  node._socketPool.routes.add(publicKey, rawStream)
-  t.ok(node._socketPool.routes.get(publicKey), 'route is registered')
+  routes.add(publicKey, rawStream)
+  t.ok(routes.get(publicKey), 'route is registered')
 
   socket.closing = true
-  t.absent(node._socketPool.routes.get(publicKey), 'closing socket route is ignored')
-  t.absent(node._socketPool.routes.get(publicKey), 'closing socket route is removed')
+  t.absent(routes.get(publicKey), 'closing socket route is ignored')
+  t.absent(routes.get(publicKey), 'closing socket route is removed')
 
   await node.destroy()
 })

--- a/test/pool.js
+++ b/test/pool.js
@@ -136,3 +136,25 @@ test('socket pool ignores closing reusable routes', async function (t) {
 
   await node.destroy()
 })
+
+test('socket pool replaces closing reusable routes', async function (t) {
+  const node = createDHT({ bootstrap: [], ephemeral: true })
+  const routes = node._socketPool.routes
+  const publicKey = Buffer.alloc(32, 1)
+
+  const closingSocket = new EventEmitter()
+  const closingStream = new EventEmitter()
+  closingStream.socket = closingSocket
+
+  routes.add(publicKey, closingStream)
+  closingSocket.closing = true
+
+  const replacementSocket = new EventEmitter()
+  const replacementStream = new EventEmitter()
+  replacementStream.socket = replacementSocket
+
+  routes.add(publicKey, replacementStream)
+  t.is(routes.get(publicKey).socket, replacementSocket, 'closing route is replaced')
+
+  await node.destroy()
+})

--- a/test/pool.js
+++ b/test/pool.js
@@ -130,6 +130,7 @@ test('socket pool ignores closing reusable routes', async function (t) {
 
   socket.closing = true
   t.absent(routes.get(publicKey), 'closing socket route is ignored')
+  // Reset closing so the next lookup proves the stale route was removed.
   socket.closing = false
   t.absent(routes.get(publicKey), 'closing socket route is removed')
 

--- a/test/pool.js
+++ b/test/pool.js
@@ -130,6 +130,7 @@ test('socket pool ignores closing reusable routes', async function (t) {
 
   socket.closing = true
   t.absent(routes.get(publicKey), 'closing socket route is ignored')
+  socket.closing = false
   t.absent(routes.get(publicKey), 'closing socket route is removed')
 
   await node.destroy()

--- a/test/pool.js
+++ b/test/pool.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
-const { swarm } = require('./helpers')
+const { EventEmitter } = require('events')
+const { swarm, createDHT } = require('./helpers')
 
 test('connection pool, client side', async function (t) {
   const [a, b] = await swarm(t)
@@ -113,3 +114,25 @@ test('connection pool, client and server side', async function (t) {
 })
 
 function noop() {}
+
+test('socket pool ignores closing reusable routes', async function (t) {
+  const node = createDHT({ bootstrap: [], ephemeral: true })
+  const publicKey = Buffer.alloc(32, 1)
+
+  const socket = new EventEmitter()
+  socket.closing = false
+
+  const rawStream = new EventEmitter()
+  rawStream.socket = socket
+  rawStream.remoteHost = '127.0.0.1'
+  rawStream.remotePort = 1234
+
+  node._socketPool.routes.add(publicKey, rawStream)
+  t.ok(node._socketPool.routes.get(publicKey), 'route is registered')
+
+  socket.closing = true
+  t.absent(node._socketPool.routes.get(publicKey), 'closing socket route is ignored')
+  t.absent(node._socketPool.routes.get(publicKey), 'closing socket route is removed')
+
+  await node.destroy()
+})


### PR DESCRIPTION
Reusable socket routes were previously removed only after the underlying socket emitted close. During the interval between calling socket.close() and receiving that event, route lookup could return a socket with socket.closing === true.
Attempting to reuse that route causes an unnecessary failed connection attempt before falling back to the normal connection path, potentially increasing reconnect latency and flakiness during connection churn.

This change:
- Removes closing routes during lookup.
- Replaces a closing route when a healthy route for the same peer is registered.


Co-authored with AI