### PR TITLE
Keep LAN shortcut from blocking holepunch fallback

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -257,6 +257,8 @@ async function holepunch(c, opts) {
       if (!remoteHolepunchable) return
 
       function onlanconnect() {
+        // LAN and holepunch completions both converge through onsocket,
+        // which claims c.rawStream once and ignores later winners.
         if (isDone(c)) return
         c.onsocket(socket, addr.port, addr.host)
       }

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -219,7 +219,6 @@ async function holepunch(c, opts) {
   let { relayAddress, serverAddress, clientAddress, payload } = c.connect
 
   const remoteHolepunchable = !!(payload.holepunch && payload.holepunch.relays.length)
-
   const relayed = diffAddress(serverAddress, relayAddress)
 
   if (payload.firewall === FIREWALL.OPEN || (relayed && !remoteHolepunchable)) {
@@ -243,7 +242,9 @@ async function holepunch(c, opts) {
     return
   }
 
-  // TODO: would be better to just try local addrs in the background whilst continuing with other strategies...
+  // Race the LAN shortcut with normal holepunch when possible. A blocked LAN ping
+  // should not abort a connection that can still holepunch. If the remote is not
+  // holepunchable, the LAN ping is the only remaining path.
   if (c.lan && relayed && clientAddress.host === serverAddress.host) {
     const serverAddresses = payload.addresses4.filter(onlyNonReserved)
 
@@ -252,14 +253,19 @@ async function holepunch(c, opts) {
       const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
 
       const socket = c.dht.io.serverSocket
-      try {
-        await c.dht.ping(addr)
-      } catch {
-        maybeDestroyEncryptedSocket(c, HOLEPUNCH_ABORTED())
-        return
+      c.dht.ping(addr).then(onlanconnect, onlanerror)
+      if (!remoteHolepunchable) return
+
+      function onlanconnect() {
+        if (isDone(c)) return
+        c.onsocket(socket, addr.port, addr.host)
       }
-      c.onsocket(socket, addr.port, addr.host)
-      return
+
+      function onlanerror() {
+        if (!remoteHolepunchable) {
+          maybeDestroyEncryptedSocket(c, HOLEPUNCH_ABORTED())
+        }
+      }
     }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,7 +14,6 @@ const {
   closeRelayConnection,
   destroyRelayConnection
 } = require('./relay-connection')
-const { isPrivate } = require('bogon')
 const { ALREADY_LISTENING, NODE_DESTROYED, KEYPAIR_ALREADY_USED } = require('./errors')
 
 const HANDSHAKE_CLEAR_WAIT = 10000
@@ -423,20 +422,6 @@ module.exports = class Server extends EventEmitter {
       if (hs.relayToken === null) hs.rawStream.destroy()
     }
 
-    if (!direct && clientAddress.host === serverAddress.host) {
-      const clientAddresses = remotePayload.addresses4.filter(onlyPrivateHosts)
-
-      if (clientAddresses.length > 0 && this._shareLocalAddress) {
-        const myAddresses = await this._localAddresses()
-        const addr = Holepuncher.matchAddress(myAddresses, clientAddresses)
-
-        if (addr) {
-          hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
-          return hs
-        }
-      }
-    }
-
     if (this._closing || this.suspended) return null
 
     if (ourRemoteAddr || this._neverPunch) {
@@ -712,10 +697,6 @@ function defaultCreateHandshake(keyPair, remotePublicKey) {
 
 function defaultCreateSecretStream(isInitiator, rawStream, opts) {
   return new NoiseSecretStream(isInitiator, rawStream, opts)
-}
-
-function onlyPrivateHosts(addr) {
-  return isPrivate(addr.host)
 }
 
 function isRelay(relaySocket, socket, port, host) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -213,7 +213,7 @@ module.exports = class Server extends EventEmitter {
     return this.dht.validateLocalAddresses(Holepuncher.localAddresses(this.dht.io.serverSocket))
   }
 
-  async _addHandshake(k, noise, clientAddress, { from, to: serverAddress, socket }, direct) {
+  async _addHandshake(k, noise, clientAddress, { socket }, direct) {
     let id = this._holepunches.indexOf(null)
     if (id === -1) id = this._holepunches.push(null) - 1
 

--- a/test/connections.js
+++ b/test/connections.js
@@ -184,6 +184,9 @@ test('createServer + connect - force holepunch', async function (t) {
 test('createServer + connect - failed LAN ping falls back to holepunch', async function (t) {
   const [boot] = await swarm(t)
 
+  // Use loopback to deterministically enter the same-LAN shortcut in CI.
+  // This does not model NAT; the injected ping failure below verifies that
+  // a blocked LAN shortcut still falls through to normal holepunch.
   const bootstrap = [{ host: '127.0.0.1', port: boot.address().port }]
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })

--- a/test/connections.js
+++ b/test/connections.js
@@ -182,12 +182,12 @@ test('createServer + connect - force holepunch', async function (t) {
 })
 
 test('createServer + connect - failed LAN ping falls back to holepunch', async function (t) {
-  const [boot] = await swarm(t)
+  const { bootstrap } = await swarm(t)
 
-  // Use loopback to deterministically enter the same-LAN shortcut in CI.
-  // This does not model NAT; the injected ping failure below verifies that
-  // a blocked LAN shortcut still falls through to normal holepunch.
-  const bootstrap = [{ host: '127.0.0.1', port: boot.address().port }]
+  // The test nodes bind to loopback, which deterministically enters the
+  // same-LAN shortcut. This does not model NAT; the injected ping failure
+  // below verifies that a blocked LAN shortcut still falls through to normal
+  // holepunch.
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 

--- a/test/connections.js
+++ b/test/connections.js
@@ -181,6 +181,73 @@ test('createServer + connect - force holepunch', async function (t) {
   await b.destroy()
 })
 
+test('createServer + connect - failed LAN ping falls back to holepunch', async function (t) {
+  const [boot] = await swarm(t)
+
+  const bootstrap = [{ host: '127.0.0.1', port: boot.address().port }]
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  await a.fullyBootstrapped()
+  await b.fullyBootstrapped()
+
+  const lc = t.test('socket lifecycle')
+  lc.plan(5)
+
+  const server = a.createServer(function (socket) {
+    lc.pass('server side opened')
+
+    socket.once('data', function (data) {
+      lc.alike(data, Buffer.from('hello'))
+      socket.end('world')
+    })
+  })
+
+  await server.listen()
+
+  const serverPort = a.io.serverSocket.address().port
+  const ping = b.ping.bind(b)
+  let blockedLanPing = false
+
+  b.ping = function (addr, opts) {
+    if (addr.host === '127.0.0.1' && addr.port === serverPort) {
+      blockedLanPing = true
+      return Promise.reject(new Error('LAN ping blocked'))
+    }
+    return ping(addr, opts)
+  }
+
+  const socket = b.connect(server.publicKey, {
+    fastOpen: false,
+    holepunch() {
+      lc.pass('client used normal holepunch')
+      return true
+    }
+  })
+
+  socket.once('open', function () {
+    lc.pass('client side opened')
+    socket.write('hello')
+  })
+
+  socket.once('data', function (data) {
+    lc.alike(data, Buffer.from('world'))
+    socket.end()
+  })
+
+  socket.once('error', function (err) {
+    lc.fail('client should not error: ' + err.code)
+  })
+
+  await lc
+
+  t.ok(blockedLanPing, 'exercised the LAN ping failure path')
+
+  await server.close()
+  await a.destroy()
+  await b.destroy()
+})
+
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)
 


### PR DESCRIPTION
When two peers appear to be on the same network, `connect()` currently tries the server's LAN address first. If that LAN ping fails, the connection aborts with `HOLEPUNCH_ABORTED` before the normal holepunch path gets a chance to run.

That means LAN cases with firewalls/default-deny incoming rules can fail even when the regular UDX holepunch path through the observed NAT address would work.

This changes the LAN shortcut to be opportunistic when the remote is holepunchable:

- still try the LAN ping as a fast path
- do not let a failed LAN ping abort the connection before normal holepunch
- keep the previous abort behavior when the remote is not holepunchable and there is no fallback path
- keep the server-side holepunch payload/puncher setup available for same-LAN peers

## Testing

I added testing for the fallback behaivour in the PR. 

But also did a LAN/hairpin repro:

I also tested the same failure shape as #210 with a Docker-based LAN/NAT setup:

- two peers on the same simulated LAN
- both peers behind the same simulated NAT
- direct LAN UDP to the server blocked
- `ufw default deny incoming` enabled on the peers
- hairpin NAT available through the externally observed address

On `origin/main`, the client failed with `HOLEPUNCH_ABORTED` before the normal holepunch hook ran.

On this branch, the failed LAN ping no longer stopped the connection. The client reached the normal holepunch path and successfully exchanged data with the server.

I also ran this repro inside an Ubuntu 24.04 Lima VM with rootful Docker, so the UFW/firewall behavior was tested in a Linux environment.


If needed I can provide the repro scripts used for this. 

------ 

Ref and praise to  https://github.com/holepunchto/hyperdht/pull/236 for the initial solution attempt. 

Addresses the original failure mode reported in #112: when peers appear same-LAN, a failed LAN shortcut can abort with HOLEPUNCH_ABORTED before normal holepunch gets a chance to run. Closes https://github.com/holepunchto/hyperdht/issues/210


------ 


Co-Written with AI