### PR TITLE
Prefer low-rtt announce relays

### DIFF
--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -298,12 +298,12 @@ function resolved(ps) {
 }
 
 function pickBest(replies) {
-  const candidates = replies.slice(0, RTT_CANDIDATE_WINDOW)
-  const ranked = candidates.map((reply, index) => ({ reply, index }))
-
-  ranked.sort((a, b) => a.reply.rtt - b.reply.rtt || a.index - b.index)
-
-  return ranked.slice(0, MAX_ANNOUNCE_RELAYS).map(({ reply }) => reply)
+  return replies
+    .slice(0, RTT_CANDIDATE_WINDOW)
+    .map((reply, index) => ({ reply, index }))
+    .sort((a, b) => a.reply.rtt - b.reply.rtt || a.index - b.index)
+    .slice(0, MAX_ANNOUNCE_RELAYS)
+    .map(({ reply }) => reply)
 }
 
 function noop() {}

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -8,6 +8,8 @@ const Persistent = require('./persistent')
 const { COMMANDS } = require('./constants')
 
 const MIN_ACTIVE = 3
+const MAX_ANNOUNCE_RELAYS = 3
+const RTT_CANDIDATE_WINDOW = 8
 
 module.exports = class Announcer {
   constructor(dht, keyPair, target, opts = {}) {
@@ -296,8 +298,17 @@ function resolved(ps) {
 }
 
 function pickBest(replies) {
-  // TODO: pick the ones closest to us RTT wise
-  return replies.slice(0, 3)
+  const candidates = replies.slice(0, RTT_CANDIDATE_WINDOW)
+  const ranked = candidates.map((reply, index) => ({ reply, index }))
+
+  ranked.sort((a, b) => {
+    const ar = Number.isFinite(a.reply.rtt) ? a.reply.rtt : Infinity
+    const br = Number.isFinite(b.reply.rtt) ? b.reply.rtt : Infinity
+
+    return ar - br || a.index - b.index
+  })
+
+  return ranked.slice(0, MAX_ANNOUNCE_RELAYS).map(({ reply }) => reply)
 }
 
 function noop() {}

--- a/lib/announcer.js
+++ b/lib/announcer.js
@@ -301,12 +301,7 @@ function pickBest(replies) {
   const candidates = replies.slice(0, RTT_CANDIDATE_WINDOW)
   const ranked = candidates.map((reply, index) => ({ reply, index }))
 
-  ranked.sort((a, b) => {
-    const ar = Number.isFinite(a.reply.rtt) ? a.reply.rtt : Infinity
-    const br = Number.isFinite(b.reply.rtt) ? b.reply.rtt : Infinity
-
-    return ar - br || a.index - b.index
-  })
+  ranked.sort((a, b) => a.reply.rtt - b.reply.rtt || a.index - b.index)
 
   return ranked.slice(0, MAX_ANNOUNCE_RELAYS).map(({ reply }) => reply)
 }

--- a/test/announces.js
+++ b/test/announces.js
@@ -197,7 +197,7 @@ test('server announces relay addrs', async function (t) {
 test('announcer prefers lower rtt among close-enough replies', async function (t) {
   const keyPair = DHT.keyPair()
   const target = DHT.hash(Buffer.from('rtt-ranked-announces'))
-  const rtts = [80, 70, 60, 50, 40, 30, 20, 10, 1, 2]
+  const rtts = [80, 70, 20, 20, 40, 20, 60, 10, 1, 2]
   const replies = rtts.map((rtt, i) => {
     return {
       token: b4a.alloc(32, i),
@@ -237,9 +237,9 @@ test('announcer prefers lower rtt among close-enough replies', async function (t
   await announcer._update()
 
   t.alike(
-    announced.sort((a, b) => a - b),
-    [10005, 10006, 10007],
-    'announced to lowest-rtt replies inside the candidate window'
+    announced,
+    [10007, 10002, 10003],
+    'announced to lowest-rtt replies and kept reply order for equal rtt'
   )
   t.absent(announced.includes(10008), 'ignored lower-rtt reply outside the candidate window')
 })

--- a/test/announces.js
+++ b/test/announces.js
@@ -5,6 +5,7 @@ const messages = require('../lib/messages.js')
 const { swarm, toArray } = require('./helpers')
 const DHT = require('../')
 const HyperDHT = require('../')
+const Announcer = require('../lib/announcer')
 const { COMMANDS } = require('../lib/constants.js')
 
 test('server listen and findPeer', async function (t) {
@@ -191,6 +192,56 @@ test('server announces relay addrs', async function (t) {
 
     t.ok(found, 'found addr')
   }
+})
+
+test('announcer prefers lower rtt among close-enough replies', async function (t) {
+  const keyPair = DHT.keyPair()
+  const target = DHT.hash(Buffer.from('rtt-ranked-announces'))
+  const rtts = [80, 70, 60, 50, 40, 30, 20, 10, 1, 2]
+  const replies = rtts.map((rtt, i) => {
+    return {
+      token: b4a.alloc(32, i),
+      rtt,
+      from: {
+        id: b4a.alloc(32, i + 1),
+        host: '127.0.0.1',
+        port: 10000 + i
+      },
+      to: {
+        host: '127.0.0.1',
+        port: 20000 + i
+      }
+    }
+  })
+  const announced = []
+  const dht = {
+    firewalled: true,
+    destroyed: false,
+    findPeer() {
+      return {
+        closestReplies: replies,
+        closestNodes: replies.map((reply) => reply.from),
+        finished: () => Promise.resolve()
+      }
+    },
+    request(req, to) {
+      t.is(req.command, COMMANDS.ANNOUNCE)
+      announced.push(to.port)
+      return Promise.resolve({ error: 0 })
+    }
+  }
+  const announcer = new Announcer(dht, keyPair, target, {
+    signAnnounce: () => b4a.alloc(64)
+  })
+
+  await announcer._update()
+
+  t.alike(
+    announced.sort((a, b) => a - b),
+    [10005, 10006, 10007],
+    'announced to lowest-rtt replies inside the candidate window'
+  )
+  t.absent(announced.includes(10008), 'ignored lower-rtt reply outside the candidate window')
 })
 
 test('connect when we relay ourself', async function (t) {


### PR DESCRIPTION
Prefer lower-RTT announce relays within a small DHT-distance candidate window.

In public-DHT testing this reduced average connect-open time by 117ms (~6%) and p95 connect-open time by 275ms (~11%), while selected relay RTT p95 dropped from 242ms to 37ms.


Previously the announcer used the first 3 closest replies directly, but with this PR: It keeps DHT locality by only considering the first 8 closest replies, then selects the 3 lowest-RTT candidates from that window.

The old behavior could pick high-latency rendezvous relays even when lower-latency candidates were already available nearby. 

## Testing

Som unit tests where added also below a Public DHT experiment was performed. 

### Public DHT experiment

Ran public-DHT holepunch attempts using hosted VMs, with both peers forced to `firewalled: true` so the consistent holepunch path was exercised.

Branch comparison, 30 attempts per branch:

| Branch | Success | Open avg | Open p50 | Open p95 | Data avg | Data p95 | Selected RTT avg | Selected RTT p95 |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| `main` | 30/30 | 1857ms | 1819ms | 2436ms | 1958ms | 2481ms | 75ms | 242ms |
| `fix/rtt-aware-announcer-relays` | 30/30 | 1740ms | 1723ms | 2161ms | 1816ms | 2342ms | 19ms | 37ms |

Window comparison, 30 attempts per window:

| Window | Success | Open avg | Open p95 | Data avg | Data p95 | Selected RTT avg | Selected RTT p95 | Rank avg | Rank p95 |
|---:|---:|---:|---:|---:|---:|---:|---:|---:|---:|
| 3 | 30/30 | 1771ms | 2340ms | 1844ms | 2388ms | 72ms | 242ms | 1 | 2 |
| 5 | 30/30 | 1733ms | 2075ms | 1809ms | 2121ms | 32ms | 97ms | 2 | 4 |
| 8 | 30/30 | 1738ms | 2066ms | 1792ms | 2111ms | 17ms | 27ms | 3 | 7 |
| 10 | 30/30 | 1689ms | 2274ms | 1743ms | 2357ms | 14ms | 25ms | 4 | 9 |
| 12 | 30/30 | 1733ms | 2292ms | 1795ms | 2340ms | 14ms | 23ms | 5 | 10 |
| 15 | 30/30 | 1734ms | 2479ms | 1794ms | 2527ms | 13ms | 23ms | 7 | 13 |
| 20 | 30/30 | 1672ms | 2043ms | 1717ms | 2087ms | 9ms | 20ms | 9 | 19 |

`Selected RTT` is the RTT from the announcing node to the DHT nodes selected as announce/rendezvous relays.

`Rank` is the selected node position in `closestReplies`; lower rank means closer to the DHT target.

Window `8` (and what this PR chooses as the default value now), is a conservative cutoff: it captures most of the selected-RTT improvement over the current behavior, while avoiding the larger DHT-rank drift seen with bigger windows.

Co-written with AI