### PR TITLE
Unflake 'connection pool, server side' test on udx 1.20

### DIFF
--- a/test/pool.js
+++ b/test/pool.js
@@ -32,56 +32,51 @@ test('connection pool, client side', async function (t) {
 })
 
 test('connection pool, server side', async function (t) {
+  const tConns = t.test('connections')
+  tConns.plan(4)
+  const tOpen1 = t.test('open 1')
+  tOpen1.plan(1)
+  const tOpen2 = t.test('open 2')
+  tOpen2.plan(1)
+  const tError1 = t.test('error')
+  tError1.plan(1)
+
   const [a, b] = await swarm(t)
 
   const pool = a.pool()
-  pool.on('connection', () => t.pass('connection on pool'))
+  pool.on('connection', () => tConns.pass('connection on pool'))
 
-  const server = a.createServer({ pool }, (socket) => {
-    t.pass('connection on server')
-    socket.end()
+  const server = a.createServer({ pool }, (conn) => {
+    conn.on('error', noop)
+    tConns.pass('connection on server')
   })
 
   await server.listen()
 
-  const open = t.test('open')
-  open.plan(2)
-  let atLeastOneOpen = false
-  let isStream1 = false
+  const socket1 = b.connect(server.publicKey)
+  socket1
+    .on('open', () => {
+      tOpen1.pass('1st stream opened')
+    })
+    .on('error', (e) => {
+      tError1.pass('1st stream errors when 2nd socket opens')
+    })
 
-  {
-    const socket = b.connect(server.publicKey)
-    socket
-      .on('open', () => {
-        if (atLeastOneOpen) return
-        open.pass('1st stream opened')
-        atLeastOneOpen = true
-        isStream1 = true
-      })
-      .on('error', noop)
-      .on('close', () => {
-        if (isStream1) open.pass('1st stream closed')
-      })
-      .end()
-  }
-  {
-    const socket = b.connect(server.publicKey)
-    socket
-      .on('open', () => {
-        if (atLeastOneOpen) return
+  await tOpen1
 
-        open.pass('2nd stream opened')
-        atLeastOneOpen = true
-      })
-      .on('error', noop)
-      .on('close', () => {
-        if (!isStream1) open.pass('2nd stream closed')
-      })
-      .end()
-  }
+  const socket2 = b.connect(server.publicKey)
+  socket2
+    .on('open', () => {
+      tOpen2.pass('2nd stream opened')
+    })
+    .on('error', () => {
+      t.fail('should not error')
+    })
 
-  await open
-  t.ok(atLeastOneOpen, 'verify one client opened')
+  await tOpen2
+  await tError1
+
+  socket2.end()
 
   await server.close()
 })

--- a/test/pool.js
+++ b/test/pool.js
@@ -47,18 +47,20 @@ test('connection pool, server side', async function (t) {
   const open = t.test('open')
   open.plan(2)
   let atLeastOneOpen = false
+  let isStream1 = false
 
   {
     const socket = b.connect(server.publicKey)
     socket
       .on('open', () => {
         if (atLeastOneOpen) return
-
         open.pass('1st stream opened')
         atLeastOneOpen = true
+        isStream1 = true
       })
-      .on('error', () => {
-        open.pass('1st stream errored')
+      .on('error', noop)
+      .on('close', () => {
+        if (isStream1) open.pass('1st stream closed')
       })
       .end()
   }
@@ -71,8 +73,9 @@ test('connection pool, server side', async function (t) {
         open.pass('2nd stream opened')
         atLeastOneOpen = true
       })
-      .on('error', () => {
-        open.pass('2nd stream errored')
+      .on('error', noop)
+      .on('close', () => {
+        if (!isStream1) open.pass('2nd stream closed')
       })
       .end()
   }
@@ -113,3 +116,5 @@ test('connection pool, client and server side', async function (t) {
 
   await server.close()
 })
+
+function noop() {}


### PR DESCRIPTION
<strike>With UDX 1.20.6, there's a code path where the stream that got selected does not error, but closes cleanly. I think the previous test was relying on undefined behaviour, so I modified it to rely on the 'close' event instead, but I don't have full context for why ti was previously listening on 'error', so please don't merge without sanity checking that</strike>

Clarified test intent and updated the test to better reflect that instead