### PR TITLE
fix: correct error constructor reference in STREAM_NOT_CONNECTED

### DIFF
--- a/lib/errors.js
+++ b/lib/errors.js
@@ -85,7 +85,7 @@ module.exports = class DHTError extends Error {
   }
 
   static STREAM_NOT_CONNECTED(msg = 'Stream is not connected') {
-    return new DHTError(msg, 'STREAM_NOT_CONNECTED', DHTError.STREAM_DISCONNECTED)
+    return new DHTError(msg, 'STREAM_NOT_CONNECTED', DHTError.STREAM_NOT_CONNECTED)
   }
 
   static SERVER_INCOMPATIBLE(msg = 'Server is using an incompatible version') {


### PR DESCRIPTION
Corrects a runtime error in `lib/errors.js` where the `STREAM_NOT_CONNECTED` static method incorrectly referenced a non-existent `STREAM_DISCONNECTED` static method for stack trace generation. This change ensures the proper method is referenced to allow correct stack trace capture.