### PR TITLE
Validate upgrading to direct when changing remote from relay to direct

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -11,7 +11,7 @@ const Holepuncher = require('./holepuncher')
 const Sleeper = require('./sleeper')
 const {
   clearRelayTimeout,
-  closeRelayConnection,
+  confirmDirectUpgrade,
   destroyRelayConnection
 } = require('./relay-connection')
 const { FIREWALL, ERROR } = require('./constants')
@@ -500,28 +500,9 @@ async function connectThroughNode(c, address, socket) {
 
     if (c.rawStream.connected) {
       c.validUpgrade = true
-      const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
-      const confirmDirect = () => {
-        if (c.validUpgrade) {
-          closeRelayConnection(c)
-          if (c.rawStream) c.rawStream.off('data', confirmDirect)
-        }
-        c.validUpgrade = true // reset, aka assume from direct
-      }
-
-      if (remoteChanging) {
-        remoteChanging.then(() => {
-          if (c.rawStream) {
-            c.rawStream.on('data', confirmDirect)
-          } else {
-            // TODO verify this gets hit, probably via queue packets before remote change
-            closeRelayConnection(c)
-          }
-        })
-        remoteChanging.catch(safetyCatch)
-      } else {
-        c.rawStream.on('data', confirmDirect)
-      }
+      const rawStream = c.rawStream
+      const remoteChanging = rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
+      confirmDirectUpgrade(c, rawStream, remoteChanging)
     } else {
       // cache the relay addrs for a future reconnect, we prefer the remote one so they
       // can give us the correct ones from their pov

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -102,6 +102,7 @@ module.exports = function connect(dht, publicKey, opts = {}) {
     relaySocket: null,
     relayClient: null,
     relayPaired: false,
+    validUpgrade: true,
     relayKeepAlive: opts.relayKeepAlive || 5000
   }
 
@@ -135,9 +136,11 @@ module.exports = function connect(dht, publicKey, opts = {}) {
     // Check if the traffic originated from the socket on which we're expecting relay traffic. If so,
     // we haven't hole punched yet and the other side is just sending us traffic through the relay.
     if (c.relaySocket && isRelay(c.relaySocket, socket, port, host)) {
+      c.validUpgrade = false
       return false
     }
 
+    c.validUpgrade = true
     if (c.onsocket) {
       c.onsocket(socket, port, host)
     } else {
@@ -496,15 +499,29 @@ async function connectThroughNode(c, address, socket) {
     if (c.rawStream === null) return // Already hole punched
 
     if (c.rawStream.connected) {
-      // Once this fires, changeRemote has moved the raw stream onto the direct path.
-      c.rawStream.once('remote-changed', () => closeRelayConnection(c))
-
+      c.validUpgrade = true
       const remoteChanging = c.rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
-      // remote-changed is local, so send one UDX message before relay cleanup
-      // to let the peer observe the direct path too.
-      c.rawStream.trySend(b4a.alloc(0))
+      const confirmDirect = () => {
+        if (c.validUpgrade) {
+          closeRelayConnection(c)
+          if (c.rawStream) c.rawStream.off('data', confirmDirect)
+        }
+        c.validUpgrade = true // reset, aka assume from direct
+      }
 
-      if (remoteChanging) remoteChanging.catch(safetyCatch)
+      if (remoteChanging) {
+        remoteChanging.then(() => {
+          if (c.rawStream) {
+            c.rawStream.on('data', confirmDirect)
+          } else {
+            // TODO verify this gets hit, probably via queue packets before remote change
+            closeRelayConnection(c)
+          }
+        })
+        remoteChanging.catch(safetyCatch)
+      } else {
+        c.rawStream.on('data', confirmDirect)
+      }
     } else {
       // cache the relay addrs for a future reconnect, we prefer the remote one so they
       // can give us the correct ones from their pov

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -499,7 +499,6 @@ async function connectThroughNode(c, address, socket) {
     if (c.rawStream === null) return // Already hole punched
 
     if (c.rawStream.connected) {
-      c.validUpgrade = true
       const rawStream = c.rawStream
       const remoteChanging = rawStream.changeRemote(socket, c.connect.payload.udx.id, port, host)
       confirmDirectUpgrade(c, rawStream, remoteChanging)

--- a/lib/relay-connection.js
+++ b/lib/relay-connection.js
@@ -1,5 +1,9 @@
+const b4a = require('b4a')
+const safetyCatch = require('safety-catch')
+
 exports.clearRelayTimeout = clearRelayTimeout
 exports.closeRelayConnection = closeRelayConnection
+exports.confirmDirectUpgrade = confirmDirectUpgrade
 exports.destroyRelayConnection = destroyRelayConnection
 
 function clearRelayTimeout(connectionOrHandshake) {
@@ -11,6 +15,42 @@ function closeRelayConnection(connectionOrHandshake) {
   const socket = resetRelayConnection(connectionOrHandshake)
 
   if (socket) socket.end()
+}
+
+function confirmDirectUpgrade(connectionOrHandshake, rawStream, remoteChanging) {
+  const cleanup = () => {
+    rawStream.off('data', ondirect)
+    rawStream.off('message', ondirect)
+    rawStream.off('close', cleanup)
+  }
+
+  function ondirect() {
+    if (!connectionOrHandshake.validUpgrade) {
+      // reset, aka assume from direct
+      connectionOrHandshake.validUpgrade = true
+      return
+    }
+
+    cleanup()
+    closeRelayConnection(connectionOrHandshake)
+  }
+
+  const confirm = () => {
+    rawStream.on('data', ondirect)
+    rawStream.on('message', ondirect)
+    rawStream.once('close', cleanup)
+
+    // Use a raw UDX message to make the peer observe the direct path without
+    // writing application data into the secret stream.
+    if (rawStream.trySend) rawStream.trySend(b4a.alloc(0))
+  }
+
+  if (!remoteChanging) {
+    confirm()
+    return
+  }
+
+  remoteChanging.then(confirm).catch(safetyCatch)
 }
 
 function destroyRelayConnection(connectionOrHandshake) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -331,7 +331,6 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('close', onrawstreamclose)
 
         if (hs.rawStream.connected) {
-          hs.validUpgrade = true
           const rawStream = hs.rawStream
           const remoteChanging = rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
           confirmDirectUpgrade(hs, rawStream, remoteChanging)

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,7 +11,7 @@ const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
 const {
   clearRelayTimeout,
-  closeRelayConnection,
+  confirmDirectUpgrade,
   destroyRelayConnection
 } = require('./relay-connection')
 const { ALREADY_LISTENING, NODE_DESTROYED, KEYPAIR_ALREADY_USED } = require('./errors')
@@ -332,28 +332,9 @@ module.exports = class Server extends EventEmitter {
 
         if (hs.rawStream.connected) {
           hs.validUpgrade = true
-          const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
-          const confirmDirect = () => {
-            if (hs.validUpgrade) {
-              closeRelayConnection(hs)
-              if (hs.rawStream) hs.rawStream.off('data', confirmDirect)
-            }
-            hs.validUpgrade = true // reset, aka assume from direct
-          }
-
-          // Once this fires, changeRemote has moved the raw stream onto the direct path.
-          if (remoteChanging) {
-            remoteChanging.then(() => {
-              if (hs.rawStream) {
-                hs.rawStream.on('data', confirmDirect)
-              } else {
-                closeRelayConnection(hs)
-              }
-            })
-            remoteChanging.catch(safetyCatch)
-          } else {
-            hs.rawStream.on('data', confirmDirect)
-          }
+          const rawStream = hs.rawStream
+          const remoteChanging = rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
+          confirmDirectUpgrade(hs, rawStream, remoteChanging)
         } else {
           hs.rawStream.connect(socket, remotePayload.udx.id, port, host)
           hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {

--- a/lib/server.js
+++ b/lib/server.js
@@ -235,7 +235,8 @@ module.exports = class Server extends EventEmitter {
       relayToken: null,
       relaySocket: null,
       relayClient: null,
-      relayPaired: false
+      relayPaired: false,
+      validUpgrade: true
     }
 
     this._holepunches[id] = hs
@@ -291,10 +292,12 @@ module.exports = class Server extends EventEmitter {
           // Check if the traffic originated from the socket on which we're expecting relay traffic. If so,
           // we haven't hole punched yet and the other side is just sending us traffic through the relay.
           if (hs.relaySocket && isRelay(hs.relaySocket, socket, port, host)) {
+            hs.validUpgrade = false
             return false
           }
 
           hs.onsocket(socket, port, host)
+          hs.validUpgrade = true
           return false
         }
       })
@@ -328,15 +331,29 @@ module.exports = class Server extends EventEmitter {
         hs.rawStream.removeListener('close', onrawstreamclose)
 
         if (hs.rawStream.connected) {
-          // Once this fires, changeRemote has moved the raw stream onto the direct path.
-          hs.rawStream.once('remote-changed', () => closeRelayConnection(hs))
-
+          hs.validUpgrade = true
           const remoteChanging = hs.rawStream.changeRemote(socket, remotePayload.udx.id, port, host)
-          // remote-changed is local, so send one UDX message before relay cleanup
-          // to let the peer observe the direct path too.
-          hs.rawStream.trySend(b4a.alloc(0))
+          const confirmDirect = () => {
+            if (hs.validUpgrade) {
+              closeRelayConnection(hs)
+              if (hs.rawStream) hs.rawStream.off('data', confirmDirect)
+            }
+            hs.validUpgrade = true // reset, aka assume from direct
+          }
 
-          if (remoteChanging) remoteChanging.catch(safetyCatch)
+          // Once this fires, changeRemote has moved the raw stream onto the direct path.
+          if (remoteChanging) {
+            remoteChanging.then(() => {
+              if (hs.rawStream) {
+                hs.rawStream.on('data', confirmDirect)
+              } else {
+                closeRelayConnection(hs)
+              }
+            })
+            remoteChanging.catch(safetyCatch)
+          } else {
+            hs.rawStream.on('data', confirmDirect)
+          }
         } else {
           hs.rawStream.connect(socket, remotePayload.udx.id, port, host)
           hs.encryptedSocket = this.createSecretStream(false, hs.rawStream, {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -528,115 +528,149 @@ test('relay connections through node, client and server side', async function (t
 })
 
 test('relay connection upgrades to direct connection', async function (t) {
-  const { bootstrap } = await swarm(t)
+  for (const opts of [
+    { name: 'default keepalive' },
+    { name: 'without keepalive', connectionKeepAlive: false, confirmWithAppData: true },
+    { name: 'idle without keepalive', connectionKeepAlive: false }
+  ]) {
+    t.comment(opts.name)
+    const { bootstrap } = await swarm(t)
 
-  const relayNode = createDHT({ bootstrap })
-  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
-  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+    const relayNode = createDHT({ bootstrap })
+    const serverNode = createDHT({
+      bootstrap,
+      quickFirewall: false,
+      ephemeral: true,
+      connectionKeepAlive: opts.connectionKeepAlive
+    })
+    const clientNode = createDHT({
+      bootstrap,
+      quickFirewall: false,
+      ephemeral: true,
+      connectionKeepAlive: opts.connectionKeepAlive
+    })
 
-  const resumePunching = pausePunching(t, [serverNode, clientNode])
+    const resumePunching = pausePunching(t, [serverNode, clientNode])
 
-  const relayServer = new RelayServer({
-    createStream(opts) {
-      return relayNode.createRawStream({ ...opts, framed: true })
+    const relayServer = new RelayServer({
+      createStream(opts) {
+        return relayNode.createRawStream({ ...opts, framed: true })
+      }
+    })
+
+    t.teardown(() => relayServer.close())
+
+    const relaySockets = []
+    let resolveRelaySockets = null
+    const relaySocketsOpened = new Promise((resolve) => {
+      resolveRelaySockets = resolve
+    })
+
+    const relayTransportServer = relayNode.createServer(function (socket) {
+      relaySockets.push(socket)
+      // Wait until both client and server have opened their relay transport sockets.
+      if (relaySockets.length === 2) resolveRelaySockets(relaySockets)
+
+      const session = relayServer.accept(socket, { id: socket.remotePublicKey })
+      session.on('error', (err) => t.comment(err.message))
+    })
+
+    await relayTransportServer.listen()
+
+    let resolveServerSocket = null
+    const serverSocketOpened = new Promise((resolve) => {
+      resolveServerSocket = resolve
+    })
+
+    const appServer = serverNode.createServer(
+      {
+        relayThrough: relayTransportServer.publicKey,
+        shareLocalAddress: false
+      },
+      function (socket) {
+        resolveServerSocket(socket)
+
+        socket.on('data', (data) => socket.write(data))
+        socket.on('end', () => socket.end())
+      }
+    )
+
+    await appServer.listen()
+
+    const clientSocket = clientNode.connect(appServer.publicKey, {
+      fastOpen: false,
+      localConnection: false
+    })
+
+    const [serverSocket] = await Promise.all([serverSocketOpened, once(clientSocket, 'open')])
+    await relaySocketsOpened
+
+    t.is(relaySockets.length, 2, 'both peers opened relay transport sockets')
+
+    t.not(
+      serverSocket.rawStream.remotePort,
+      clientSocket.rawStream.localPort,
+      'server starts on the relayed stream'
+    )
+    t.not(
+      clientSocket.rawStream.remotePort,
+      serverSocket.rawStream.localPort,
+      'client starts on the relayed stream'
+    )
+
+    // The relayed connection should already be usable before the direct path wins.
+    const beforeUpgrade = once(clientSocket, 'data')
+    clientSocket.write(Buffer.from('before upgrade'))
+    t.alike((await beforeUpgrade)[0], Buffer.from('before upgrade'), 'relay path carries data')
+
+    const clientUpgraded = once(clientSocket.rawStream, 'remote-changed')
+    const serverUpgraded = once(serverSocket.rawStream, 'remote-changed')
+    const relaySocketsClosed = relaySockets.map((socket) => once(socket, 'close'))
+
+    resumePunching()
+
+    if (opts.confirmWithAppData) {
+      await clientUpgraded
+
+      t.ok(
+        relaySockets.every((socket) => !socket.destroyed),
+        'relay stays open until direct traffic confirms the upgrade'
+      )
+
+      // Without keepalive, the passive upgrade is confirmed by the next app write.
+      const appData = once(clientSocket, 'data')
+      clientSocket.write(Buffer.from('after upgrade'))
+      t.alike((await appData)[0], Buffer.from('after upgrade'), 'app data confirms direct path')
     }
-  })
 
-  t.teardown(() => relayServer.close())
+    await Promise.all([clientUpgraded, serverUpgraded])
+    await Promise.all(relaySocketsClosed)
+    t.pass('relay transport sockets close after direct upgrade')
 
-  const relaySockets = []
-  let resolveRelaySockets = null
-  const relaySocketsOpened = new Promise((resolve) => {
-    resolveRelaySockets = resolve
-  })
+    t.is(
+      serverSocket.rawStream.remotePort,
+      clientSocket.rawStream.localPort,
+      'server switches to the client address'
+    )
+    t.is(
+      clientSocket.rawStream.remotePort,
+      serverSocket.rawStream.localPort,
+      'client switches to the server address'
+    )
 
-  const relayTransportServer = relayNode.createServer(function (socket) {
-    relaySockets.push(socket)
-    // Wait until both client and server have opened their relay transport sockets.
-    if (relaySockets.length === 2) resolveRelaySockets(relaySockets)
-
-    const session = relayServer.accept(socket, { id: socket.remotePublicKey })
-    session.on('error', (err) => t.comment(err.message))
-  })
-
-  await relayTransportServer.listen()
-
-  let resolveServerSocket = null
-  const serverSocketOpened = new Promise((resolve) => {
-    resolveServerSocket = resolve
-  })
-
-  const appServer = serverNode.createServer(
-    {
-      relayThrough: relayTransportServer.publicKey,
-      shareLocalAddress: false
-    },
-    function (socket) {
-      resolveServerSocket(socket)
-
-      socket.on('data', (data) => socket.write(data))
-      socket.on('end', () => socket.end())
+    if (!opts.confirmWithAppData) {
+      const afterUpgrade = once(clientSocket, 'data')
+      clientSocket.write(Buffer.from('after upgrade'))
+      t.alike((await afterUpgrade)[0], Buffer.from('after upgrade'), 'direct path carries data')
     }
-  )
 
-  await appServer.listen()
+    await endAndCloseSocket(clientSocket)
+    if (!serverSocket.destroyed) await once(serverSocket, 'close')
 
-  const clientSocket = clientNode.connect(appServer.publicKey, {
-    fastOpen: false,
-    localConnection: false
-  })
-
-  const [serverSocket] = await Promise.all([serverSocketOpened, once(clientSocket, 'open')])
-  await relaySocketsOpened
-
-  t.is(relaySockets.length, 2, 'both peers opened relay transport sockets')
-
-  t.not(
-    serverSocket.rawStream.remotePort,
-    clientSocket.rawStream.localPort,
-    'server starts on the relayed stream'
-  )
-  t.not(
-    clientSocket.rawStream.remotePort,
-    serverSocket.rawStream.localPort,
-    'client starts on the relayed stream'
-  )
-
-  // The relayed connection should already be usable before the direct path wins.
-  const beforeUpgrade = once(clientSocket, 'data')
-  clientSocket.write(Buffer.from('before upgrade'))
-  t.alike((await beforeUpgrade)[0], Buffer.from('before upgrade'), 'relay path carries data')
-
-  const clientUpgraded = once(clientSocket.rawStream, 'remote-changed')
-  const serverUpgraded = once(serverSocket.rawStream, 'remote-changed')
-  const relaySocketsClosed = relaySockets.map((socket) => once(socket, 'close'))
-
-  resumePunching()
-  await Promise.all([clientUpgraded, serverUpgraded])
-  await Promise.all(relaySocketsClosed)
-  t.pass('relay transport sockets close after direct upgrade')
-
-  t.is(
-    serverSocket.rawStream.remotePort,
-    clientSocket.rawStream.localPort,
-    'server switches to the client address'
-  )
-  t.is(
-    clientSocket.rawStream.remotePort,
-    serverSocket.rawStream.localPort,
-    'client switches to the server address'
-  )
-
-  const afterUpgrade = once(clientSocket, 'data')
-  clientSocket.write(Buffer.from('after upgrade'))
-  t.alike((await afterUpgrade)[0], Buffer.from('after upgrade'), 'direct path carries data')
-
-  await endAndCloseSocket(clientSocket)
-  if (!serverSocket.destroyed) await once(serverSocket, 'close')
-
-  await relayNode.destroy()
-  await serverNode.destroy()
-  await clientNode.destroy()
+    await relayNode.destroy()
+    await serverNode.destroy()
+    await clientNode.destroy()
+  }
 })
 
 test.skip('relay several connections through node with pool', async function (t) {


### PR DESCRIPTION
Changing the remote and immediately closing the relay connection leads to situations where one side is left trying to ack the packets sent via the relay connection but unable to since the peer closed their side since the remote changed successfully.

Instead this approach uses the fact that changing the remote (whether immediately or deferred) changes the stream's socket which means that the `firewall` callback will be called for each packet received that comes from a different socket, in the case of changing remote from the relay -> direct means `firewall` only triggers from the relay.

This means the direct connection can be validated by waiting for a packet to come through that doesn't trigger the firewall. This is done by setting a flag on the connection / hs that assumes the next `data` event will be direct. The flag is set to false when the firewall is called and the socket its called with is shown to be the relay's. Once direct the relay connection is cleaned up via the normal method.

Collaborated with AI to debug.