### PR TITLE
Fix server lan prepunch

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -431,7 +431,7 @@ module.exports = class Server extends EventEmitter {
     }
 
     if (!direct && clientAddress.host === serverAddress.host) {
-      const clientAddresses = remotePayload.addresses4.filter(onlyPrivateHosts)
+      const clientAddresses = remotePayload.addresses4.filter((addr) => isPrivate(addr.host))
 
       if (clientAddresses.length > 0 && this._shareLocalAddress) {
         const myAddresses = await this._localAddresses()
@@ -728,10 +728,6 @@ function setupHolepuncher(dht, hs, remoteFirewall) {
   hs.puncher = new Holepuncher(dht, dht.session(), false, remoteFirewall)
   hs.puncher.onconnect = hs.onsocket
   hs.puncher.onabort = hs.onabort
-}
-
-function onlyPrivateHosts(addr) {
-  return isPrivate(addr.host)
 }
 
 function isRelay(relaySocket, socket, port, host) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -14,6 +14,7 @@ const {
   closeRelayConnection,
   destroyRelayConnection
 } = require('./relay-connection')
+const { isPrivate } = require('bogon')
 const { ALREADY_LISTENING, NODE_DESTROYED, KEYPAIR_ALREADY_USED } = require('./errors')
 
 const HANDSHAKE_CLEAR_WAIT = 10000
@@ -213,7 +214,7 @@ module.exports = class Server extends EventEmitter {
     return this.dht.validateLocalAddresses(Holepuncher.localAddresses(this.dht.io.serverSocket))
   }
 
-  async _addHandshake(k, noise, clientAddress, { socket }, direct) {
+  async _addHandshake(k, noise, clientAddress, { to: serverAddress, socket }, direct) {
     let id = this._holepunches.indexOf(null)
     if (id === -1) id = this._holepunches.push(null) - 1
 
@@ -227,6 +228,7 @@ module.exports = class Server extends EventEmitter {
       prepunching: null,
       firewalled: true,
       clearing: null,
+      onabort: null,
       onsocket: null,
       aborted: false,
 
@@ -422,6 +424,27 @@ module.exports = class Server extends EventEmitter {
       if (hs.relayToken === null) hs.rawStream.destroy()
     }
 
+    hs.onabort = onabort
+
+    const ensureHolepuncher = () => {
+      setupHolepuncher(this.dht, hs, remotePayload.firewall)
+    }
+
+    if (!direct && clientAddress.host === serverAddress.host) {
+      const clientAddresses = remotePayload.addresses4.filter(onlyPrivateHosts)
+
+      if (clientAddresses.length > 0 && this._shareLocalAddress) {
+        const myAddresses = await this._localAddresses()
+        const addr = Holepuncher.matchAddress(myAddresses, clientAddresses)
+
+        if (addr) {
+          hs.payload = new SecurePayload(h.holepunchSecret)
+          hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
+          return hs
+        }
+      }
+    }
+
     if (this._closing || this.suspended) return null
 
     if (ourRemoteAddr || this._neverPunch) {
@@ -430,10 +453,7 @@ module.exports = class Server extends EventEmitter {
     }
 
     hs.payload = new SecurePayload(h.holepunchSecret)
-    hs.puncher = new Holepuncher(this.dht, this.dht.session(), false, remotePayload.firewall)
-
-    hs.puncher.onconnect = hs.onsocket
-    hs.puncher.onabort = onabort
+    ensureHolepuncher()
     hs.prepunching = setTimeout(hs.puncher.destroy.bind(hs.puncher), HANDSHAKE_INITIAL_TIMEOUT)
 
     return hs
@@ -482,12 +502,15 @@ module.exports = class Server extends EventEmitter {
     if (!h) return null
 
     if (!peerAddress || this._closing !== null || this.suspended) return null
-
-    const p = h.puncher
-    if (!p || !p.socket) return this._abort(h) // not opened
+    if (!h.payload) return this._abort(h) // not opened
 
     const remotePayload = h.payload.decrypt(payload)
     if (!remotePayload) return null
+
+    setupHolepuncher(this.dht, h, remotePayload.firewall)
+
+    const p = h.puncher
+    if (!p || !p.socket) return this._abort(h) // not opened
 
     const isServerRelay = this._announcer.isRelay(req.from)
     const { error, firewall, round, punching, addresses, remoteAddress, remoteToken } =
@@ -614,7 +637,7 @@ module.exports = class Server extends EventEmitter {
       remoteToken: null
     })
 
-    h.puncher.destroy()
+    if (h.puncher) h.puncher.destroy()
 
     return { socket: this.dht.socket, payload }
   }
@@ -697,6 +720,18 @@ function defaultCreateHandshake(keyPair, remotePublicKey) {
 
 function defaultCreateSecretStream(isInitiator, rawStream, opts) {
   return new NoiseSecretStream(isInitiator, rawStream, opts)
+}
+
+function setupHolepuncher(dht, hs, remoteFirewall) {
+  if (hs.puncher) return
+
+  hs.puncher = new Holepuncher(dht, dht.session(), false, remoteFirewall)
+  hs.puncher.onconnect = hs.onsocket
+  hs.puncher.onabort = hs.onabort
+}
+
+function onlyPrivateHosts(addr) {
+  return isPrivate(addr.host)
 }
 
 function isRelay(relaySocket, socket, port, host) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -229,7 +229,6 @@ module.exports = class Server extends EventEmitter {
       firewalled: true,
       clearing: null,
       replyFromPuncher: false,
-      onabort: null,
       onsocket: null,
       aborted: false,
 
@@ -429,8 +428,6 @@ module.exports = class Server extends EventEmitter {
       if (hs.relayToken === null) hs.rawStream.destroy()
     }
 
-    hs.onabort = onabort
-
     if (!direct && clientAddress.host === serverAddress.host) {
       const clientAddresses = remotePayload.addresses4.filter((addr) => isPrivate(addr.host))
 
@@ -440,7 +437,7 @@ module.exports = class Server extends EventEmitter {
 
         if (addr) {
           hs.payload = new SecurePayload(h.holepunchSecret)
-          setupHolepuncher(this.dht, hs, remotePayload.firewall)
+          setupHolepuncher(this.dht, hs, remotePayload.firewall, onabort)
           hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
           return hs
         }
@@ -455,7 +452,7 @@ module.exports = class Server extends EventEmitter {
     }
 
     hs.payload = new SecurePayload(h.holepunchSecret)
-    setupHolepuncher(this.dht, hs, remotePayload.firewall)
+    setupHolepuncher(this.dht, hs, remotePayload.firewall, onabort)
     hs.replyFromPuncher = true
     hs.prepunching = setTimeout(hs.puncher.destroy.bind(hs.puncher), HANDSHAKE_INITIAL_TIMEOUT)
 
@@ -723,12 +720,12 @@ function defaultCreateSecretStream(isInitiator, rawStream, opts) {
   return new NoiseSecretStream(isInitiator, rawStream, opts)
 }
 
-function setupHolepuncher(dht, hs, remoteFirewall) {
+function setupHolepuncher(dht, hs, remoteFirewall, onabort) {
   if (hs.puncher) return
 
   hs.puncher = new Holepuncher(dht, dht.session(), false, remoteFirewall)
   hs.puncher.onconnect = hs.onsocket
-  hs.puncher.onabort = hs.onabort
+  hs.puncher.onabort = onabort
 }
 
 function isRelay(relaySocket, socket, port, host) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -494,6 +494,9 @@ module.exports = class Server extends EventEmitter {
 
     if (this._closing !== null || this.suspended) return null
 
+    // Routed handshake replies advertise the socket they are sent from as the
+    // server address. Same-LAN prepunch also creates a puncher, but it must
+    // keep advertising the normal server socket so the LAN shortcut can open.
     return { socket: h.replyFromPuncher ? h.puncher.socket : null, noise: h.reply }
   }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -228,7 +228,7 @@ module.exports = class Server extends EventEmitter {
       prepunching: null,
       firewalled: true,
       clearing: null,
-      handshakeSocket: null,
+      replyFromPuncher: false,
       onabort: null,
       onsocket: null,
       aborted: false,
@@ -456,7 +456,7 @@ module.exports = class Server extends EventEmitter {
 
     hs.payload = new SecurePayload(h.holepunchSecret)
     setupHolepuncher(this.dht, hs, remotePayload.firewall)
-    hs.handshakeSocket = hs.puncher.socket
+    hs.replyFromPuncher = true
     hs.prepunching = setTimeout(hs.puncher.destroy.bind(hs.puncher), HANDSHAKE_INITIAL_TIMEOUT)
 
     return hs
@@ -497,7 +497,7 @@ module.exports = class Server extends EventEmitter {
 
     if (this._closing !== null || this.suspended) return null
 
-    return { socket: h.handshakeSocket, noise: h.reply }
+    return { socket: h.replyFromPuncher ? h.puncher.socket : null, noise: h.reply }
   }
 
   async _onpeerholepunch({ id, peerAddress, payload }, req) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -228,6 +228,7 @@ module.exports = class Server extends EventEmitter {
       prepunching: null,
       firewalled: true,
       clearing: null,
+      handshakeSocket: null,
       onabort: null,
       onsocket: null,
       aborted: false,
@@ -415,6 +416,10 @@ module.exports = class Server extends EventEmitter {
       hs.aborted = true
       if (hs.prepunching) clearTimeout(hs.prepunching)
       hs.prepunching = null
+      if (hs.puncher) {
+        hs.puncher.onabort = noop
+        hs.puncher.destroy()
+      }
       if (hs.rawStream.destroyed) {
         this._clearLater(hs, id, k)
         return
@@ -426,10 +431,6 @@ module.exports = class Server extends EventEmitter {
 
     hs.onabort = onabort
 
-    const ensureHolepuncher = () => {
-      setupHolepuncher(this.dht, hs, remotePayload.firewall)
-    }
-
     if (!direct && clientAddress.host === serverAddress.host) {
       const clientAddresses = remotePayload.addresses4.filter((addr) => isPrivate(addr.host))
 
@@ -439,6 +440,7 @@ module.exports = class Server extends EventEmitter {
 
         if (addr) {
           hs.payload = new SecurePayload(h.holepunchSecret)
+          setupHolepuncher(this.dht, hs, remotePayload.firewall)
           hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)
           return hs
         }
@@ -453,7 +455,8 @@ module.exports = class Server extends EventEmitter {
     }
 
     hs.payload = new SecurePayload(h.holepunchSecret)
-    ensureHolepuncher()
+    setupHolepuncher(this.dht, hs, remotePayload.firewall)
+    hs.handshakeSocket = hs.puncher.socket
     hs.prepunching = setTimeout(hs.puncher.destroy.bind(hs.puncher), HANDSHAKE_INITIAL_TIMEOUT)
 
     return hs
@@ -494,7 +497,7 @@ module.exports = class Server extends EventEmitter {
 
     if (this._closing !== null || this.suspended) return null
 
-    return { socket: h.puncher && h.puncher.socket, noise: h.reply }
+    return { socket: h.handshakeSocket, noise: h.reply }
   }
 
   async _onpeerholepunch({ id, peerAddress, payload }, req) {
@@ -506,8 +509,6 @@ module.exports = class Server extends EventEmitter {
 
     const remotePayload = h.payload.decrypt(payload)
     if (!remotePayload) return null
-
-    setupHolepuncher(this.dht, h, remotePayload.firewall)
 
     const p = h.puncher
     if (!p || !p.socket) return this._abort(h) // not opened

--- a/test/connections.js
+++ b/test/connections.js
@@ -251,6 +251,55 @@ test('createServer + connect - failed LAN ping falls back to holepunch', async f
   await b.destroy()
 })
 
+test(
+  'createServer + connect - same-LAN explicit keypair opens server',
+  { timeout: 15000 },
+  async function (t) {
+    const { bootstrap } = await swarm(t)
+
+    const a = new DHT({ bootstrap })
+    const b = new DHT({ bootstrap })
+
+    await a.fullyBootstrapped()
+    await b.fullyBootstrapped()
+
+    const serverKeyPair = DHT.keyPair()
+    const clientKeyPair = DHT.keyPair()
+
+    let resolveServerOpened = null
+    const serverOpened = new Promise((resolve) => {
+      resolveServerOpened = resolve
+    })
+
+    const server = a.createServer(function (socket) {
+      socket.on('error', () => {})
+      socket.once('end', () => socket.end())
+      resolveServerOpened(socket)
+    })
+
+    await server.listen(serverKeyPair)
+
+    const socket = b.connect(serverKeyPair.publicKey, {
+      keyPair: clientKeyPair
+    })
+
+    socket.once('error', function (err) {
+      t.fail('client should not error: ' + err.code)
+    })
+
+    await withTimeout(once(socket, 'open'), 5000, 'client side did not open')
+    t.pass('client side opened')
+
+    await withTimeout(serverOpened, 5000, 'server side did not open')
+    t.pass('server side opened')
+
+    await endAndCloseSocket(socket)
+    await server.close()
+    await a.destroy()
+    await b.destroy()
+  }
+)
+
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)
 
@@ -884,3 +933,18 @@ test('create server with handshakeClearWait opt', async function (t) {
     t.is(server.handshakeClearWait, 10000, 'expected default')
   }
 })
+
+async function withTimeout(promise, ms, message) {
+  let timeout = null
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((resolve, reject) => {
+        timeout = setTimeout(() => reject(new Error(message)), ms)
+      })
+    ])
+  } finally {
+    clearTimeout(timeout)
+  }
+}

--- a/test/connections.js
+++ b/test/connections.js
@@ -251,54 +251,55 @@ test('createServer + connect - failed LAN ping falls back to holepunch', async f
   await b.destroy()
 })
 
-test(
-  'createServer + connect - same-LAN explicit keypair opens server',
-  { timeout: 15000 },
-  async function (t) {
-    const { bootstrap } = await swarm(t)
+test('createServer + connect - same-LAN explicit keypair opens server', async function (t) {
+  const { bootstrap } = await swarm(t)
 
-    const a = new DHT({ bootstrap })
-    const b = new DHT({ bootstrap })
+  const a = new DHT({ bootstrap })
+  const b = new DHT({ bootstrap })
 
-    await a.fullyBootstrapped()
-    await b.fullyBootstrapped()
+  await a.fullyBootstrapped()
+  await b.fullyBootstrapped()
 
-    const serverKeyPair = DHT.keyPair()
-    const clientKeyPair = DHT.keyPair()
+  const serverKeyPair = DHT.keyPair()
+  const clientKeyPair = DHT.keyPair()
+  const lc = t.test('socket lifecycle')
+  lc.plan(4)
 
-    let resolveServerOpened = null
-    const serverOpened = new Promise((resolve) => {
-      resolveServerOpened = resolve
+  const server = a.createServer(function (socket) {
+    lc.pass('server side opened')
+
+    socket.once('end', function () {
+      lc.pass('server side ended')
+      socket.end()
     })
+  })
 
-    const server = a.createServer(function (socket) {
-      socket.on('error', () => {})
-      socket.once('end', () => socket.end())
-      resolveServerOpened(socket)
-    })
+  await server.listen(serverKeyPair)
 
-    await server.listen(serverKeyPair)
+  const socket = b.connect(serverKeyPair.publicKey, {
+    keyPair: clientKeyPair
+  })
 
-    const socket = b.connect(serverKeyPair.publicKey, {
-      keyPair: clientKeyPair
-    })
+  socket.once('open', function () {
+    lc.pass('client side opened')
+  })
 
-    socket.once('error', function (err) {
-      t.fail('client should not error: ' + err.code)
-    })
+  socket.once('end', function () {
+    lc.pass('client side ended')
+  })
 
-    await withTimeout(once(socket, 'open'), 5000, 'client side did not open')
-    t.pass('client side opened')
+  socket.once('error', function (err) {
+    lc.fail('client should not error: ' + err.code)
+  })
 
-    await withTimeout(serverOpened, 5000, 'server side did not open')
-    t.pass('server side opened')
+  socket.end()
 
-    await endAndCloseSocket(socket)
-    await server.close()
-    await a.destroy()
-    await b.destroy()
-  }
-)
+  await lc
+
+  await server.close()
+  await a.destroy()
+  await b.destroy()
+})
 
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)
@@ -933,18 +934,3 @@ test('create server with handshakeClearWait opt', async function (t) {
     t.is(server.handshakeClearWait, 10000, 'expected default')
   }
 })
-
-async function withTimeout(promise, ms, message) {
-  let timeout = null
-
-  try {
-    return await Promise.race([
-      promise,
-      new Promise((resolve, reject) => {
-        timeout = setTimeout(() => reject(new Error(message)), ms)
-      })
-    ])
-  } finally {
-    clearTimeout(timeout)
-  }
-}

--- a/test/connections.js
+++ b/test/connections.js
@@ -252,6 +252,8 @@ test('createServer + connect - failed LAN ping falls back to holepunch', async f
 })
 
 test('createServer + connect - same-LAN explicit keypair opens server', async function (t) {
+  // Regression: advertising the prepunch socket as the server address can make
+  // the client mark punching done before the LAN shortcut opens the stream.
   const { bootstrap } = await swarm(t, 3)
 
   const a = new DHT({ bootstrap })

--- a/test/connections.js
+++ b/test/connections.js
@@ -252,7 +252,7 @@ test('createServer + connect - failed LAN ping falls back to holepunch', async f
 })
 
 test('createServer + connect - same-LAN explicit keypair opens server', async function (t) {
-  const { bootstrap } = await swarm(t)
+  const { bootstrap } = await swarm(t, 3)
 
   const a = new DHT({ bootstrap })
   const b = new DHT({ bootstrap })
@@ -263,13 +263,12 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   const serverKeyPair = DHT.keyPair()
   const clientKeyPair = DHT.keyPair()
   const lc = t.test('socket lifecycle')
-  lc.plan(4)
+  lc.plan(2)
 
   const server = a.createServer(function (socket) {
     lc.pass('server side opened')
 
     socket.once('end', function () {
-      lc.pass('server side ended')
       socket.end()
     })
   })
@@ -284,18 +283,13 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
     lc.pass('client side opened')
   })
 
-  socket.once('end', function () {
-    lc.pass('client side ended')
-  })
-
   socket.once('error', function (err) {
     lc.fail('client should not error: ' + err.code)
   })
 
-  socket.end()
-
   await lc
 
+  await endAndCloseSocket(socket)
   await server.close()
   await a.destroy()
   await b.destroy()


### PR DESCRIPTION
This PR restores the server-side same-LAN prepunch path (https://github.com/holepunchto/hyperdht/blob/a9371f4142a49b055e73dbe952c7716b8bffab34/lib/server.js#L426-L436)  so explicit-keypair connections can open on both peers again, while preserving the existing LAN-ping fallback to normal holepunching.

Co-written with AI