### PR TITLE
Fix duplicated push of node in HyperDHT initialization

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -53,8 +53,6 @@ async function startNodes(cnt, bootstrap) {
     const node = new HyperDHT({ host, port, anyPort: !port, bootstrap })
     await node.ready()
 
-    all.push(node)
-
     const id = all.push(node) - 1
     console.log('Node #' + id + ' bound to', node.address())
 


### PR DESCRIPTION
When running the cli and starting multiple nodes `--nodes 5` I'd expect it to start the number of nodes given

It actually counts every node twice so it never created the requested amount of nodes

```bash
> node bin.js --nodes 5
Booting DHT nodes...
Node #1 bound to { host: '0.0.0.0', family: 4, port: 46961 }
Node #3 bound to { host: '0.0.0.0', family: 4, port: 43422 }
Node #5 bound to { host: '0.0.0.0', family: 4, port: 52214 }
Fully started 5 Hyperswarm DHT nodes
```