### PR TITLE
Unref clearing timeout

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -462,6 +462,7 @@ module.exports = class Server extends EventEmitter {
   _clearLater(hs, id, k) {
     if (hs.clearing) return
     hs.clearing = setTimeout(() => this._clear(hs, id, k), this.handshakeClearWait)
+    hs.clearing.unref()
   }
 
   _clear(hs, id, k) {


### PR DESCRIPTION
A clean fix would tie into the lifecycle more explicitly, but this is strictly better than the previous behaviour where the event loop can stay alive even after the dht is destroyed.

The hyperdhtt tests themselves hang after they finish because of this issue, so this fix makes them a few seconds faster. This is trivial to see by replacing clearlater with

```
  _clearLater(hs, id, k) {
    if (hs.clearing) return
    hs.clearing = setTimeout(() => {
      console.trace('hang')
      this._clear(hs, id, k)
    }, this.handshakeClearWait)
  }

```