### PR TITLE
update address when flipping firewall

### DIFF
--- a/lib/nat.js
+++ b/lib/nat.js
@@ -140,6 +140,12 @@ module.exports = class Nat {
       return
     }
 
+    if (this.firewall === FIREWALL.OPEN) {
+      const addr = typeof this.dht.remoteAddress === 'function' ? this.dht.remoteAddress() : null
+      this.addresses = addr ? [{ host: addr.host, port: addr.port, hits: this.sampled || 1 }] : null
+      return
+    }
+
     if (this.firewall === FIREWALL.RANDOM) {
       this.addresses = [this._samplesHost[0]]
       return

--- a/lib/nat.js
+++ b/lib/nat.js
@@ -141,8 +141,13 @@ module.exports = class Nat {
     }
 
     if (this.firewall === FIREWALL.OPEN) {
+      if (this._samplesFull.length) {
+        this.addresses = [this._samplesFull[0]]
+        return
+      }
+
       const addr = typeof this.dht.remoteAddress === 'function' ? this.dht.remoteAddress() : null
-      this.addresses = addr ? [{ host: addr.host, port: addr.port, hits: this.sampled || 1 }] : null
+      this.addresses = addr ? [{ host: addr.host, port: addr.port, hits: 1 }] : null
       return
     }
 

--- a/lib/nat.js
+++ b/lib/nat.js
@@ -146,7 +146,7 @@ module.exports = class Nat {
         return
       }
 
-      const addr = typeof this.dht.remoteAddress === 'function' ? this.dht.remoteAddress() : null
+      const addr = this.dht.remoteAddress()
       this.addresses = addr ? [{ host: addr.host, port: addr.port, hits: 1 }] : null
       return
     }

--- a/test/nat.js
+++ b/test/nat.js
@@ -16,7 +16,7 @@ test('firewall - open', function (t) {
 // hand back a usable address for that case, otherwise the peer we're
 // holepunching with can never find a remoteVerifiedAddress and permanently
 // fails Holepuncher.punch()
-test.solo('firewall - open after mid-flight flip still exposes an address', function (t) {
+test('firewall - open after mid-flight flip still exposes an address', function (t) {
   const dht = {
     firewalled: true,
     remoteAddress() {

--- a/test/nat.js
+++ b/test/nat.js
@@ -9,14 +9,10 @@ test('firewall - open', function (t) {
   t.is(nat.firewall, FIREWALL.OPEN)
 })
 
-// Regression: dht-rpc re-checks whether we are firewalled on a background timer,
-// independent of any in-flight holepunch. If that check resolves (firewalled:
-// true -> false) before any nat samples have come in, the firewall flips
-// straight to OPEN with zero samples collected. _updateAddresses() must still
-// hand back a usable address for that case, otherwise the peer we're
-// holepunching with can never find a remoteVerifiedAddress and permanently
-// fails Holepuncher.punch()
-test('firewall - open after mid-flight flip still exposes an address', function (t) {
+// If the Nat is updated and dht.firewalled switches from `true` to `false`,
+// `nat.firewall` flips straight to OPEN. `_updateAddresses()` should return a
+// sample address if available.
+test('firewall - open - returns 1st sample', function (t) {
   const dht = {
     firewalled: true,
     remoteAddress() {
@@ -31,15 +27,40 @@ test('firewall - open after mid-flight flip still exposes an address', function 
   t.is(nat.addresses, null)
 
   // The background self-check resolves: we are not firewalled after all.
-  // No samples have arrived yet - this is the exact race.
   dht.firewalled = false
-  nat.update()
+  nat.add({ host: '127.0.0.1', port: 8080 }, { host: '203.0.113.7', port: 44201 })
 
   t.is(nat.firewall, FIREWALL.OPEN)
   t.alike(
     nat.addresses,
+    [{ host: '127.0.0.1', port: 8080, hits: 1 }],
+    'an OPEN nat with a sample already collected should use it instead of dht.remoteAddress()'
+  )
+})
+
+// If the Nat is unfrozen and `dht.firewalled === false`, `nat.firewall` flips
+// straight to OPEN. `_updateAddresses()` should return a its remoteAddress if a
+// sample isnt available and remoteAddress is.
+test('firewall - open with zero samples falls back to dht.remoteAddress', function (t) {
+  const dht = {
+    firewalled: false,
+    remoteAddress() {
+      return { host: '203.0.113.5', port: 44201 }
+    }
+  }
+
+  const nat = new Nat(dht, null, null)
+
+  t.is(nat.sampled, 0)
+  t.is(nat.firewall, FIREWALL.OPEN)
+  t.is(nat.addresses, null)
+
+  nat.unfreeze()
+
+  t.alike(
+    nat.addresses,
     [{ host: '203.0.113.5', port: 44201, hits: 1 }],
-    'an OPEN nat must still expose an address, or holepunch() can never find a remoteVerifiedAddress'
+    'an OPEN nat with no samples yet must still expose an address via dht.remoteAddress()'
   )
 })
 

--- a/test/nat.js
+++ b/test/nat.js
@@ -9,6 +9,40 @@ test('firewall - open', function (t) {
   t.is(nat.firewall, FIREWALL.OPEN)
 })
 
+// Regression: dht-rpc re-checks whether we are firewalled on a background timer,
+// independent of any in-flight holepunch. If that check resolves (firewalled:
+// true -> false) before any nat samples have come in, the firewall flips
+// straight to OPEN with zero samples collected. _updateAddresses() must still
+// hand back a usable address for that case, otherwise the peer we're
+// holepunching with can never find a remoteVerifiedAddress and permanently
+// fails Holepuncher.punch()
+test.solo('firewall - open after mid-flight flip still exposes an address', function (t) {
+  const dht = {
+    firewalled: true,
+    remoteAddress() {
+      return { host: '203.0.113.5', port: 44201 }
+    }
+  }
+
+  const nat = new Nat(dht, null, null)
+
+  t.is(nat.sampled, 0)
+  t.is(nat.firewall, FIREWALL.UNKNOWN)
+  t.is(nat.addresses, null)
+
+  // The background self-check resolves: we are not firewalled after all.
+  // No samples have arrived yet - this is the exact race.
+  dht.firewalled = false
+  nat.update()
+
+  t.is(nat.firewall, FIREWALL.OPEN)
+  t.alike(
+    nat.addresses,
+    [{ host: '203.0.113.5', port: 44201, hits: 1 }],
+    'an OPEN nat must still expose an address, or holepunch() can never find a remoteVerifiedAddress'
+  )
+})
+
 test('firewall - random', function (t) {
   const nat = new Nat({ firewalled: true }, null, null)
 


### PR DESCRIPTION
This is a race condition

- Racer A: the node's own bootstrap self-check (dht-rpc's _bootstrap() → the "quick NAT heuristic" → _checkIfFirewalled()). This runs automatically once you start using a freshly-constructed HyperDHT, and it can flip the shared dht.firewalled boolean from true to false within milliseconds.

- Racer B: that node's own holepunch negotiation for the in-flight connection — specifically, the moment roundPunch() builds round 1's payload, it reads c.puncher.nat.firewall and c.puncher.nat.addresses at that instant and ships them to the peer. That per-connection Nat instance derives its firewall value from the same shared dht.firewalled boolean Racer A is mutating.

-- coworking with Claude