### PR TITLE
Guard both sides of LAN fast-open races

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -254,8 +254,7 @@ async function holepunch(c, opts) {
 
     if (serverAddresses.length > 0) {
       const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
-      const matchedAddress = Holepuncher.matchAddress(myAddresses, serverAddresses)
-      const addr = matchedAddress || serverAddresses[0]
+      const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
 
       // A concurrent fast-open probe can win before the server accepts the LAN stream.
       fastOpen = false

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -257,9 +257,8 @@ async function holepunch(c, opts) {
       const matchedAddress = Holepuncher.matchAddress(myAddresses, serverAddresses)
       const addr = matchedAddress || serverAddresses[0]
 
-      // An unmatched LAN address can still be reachable, but the concurrent
-      // fast-open probe can win before the server accepts the LAN stream.
-      if (!matchedAddress) fastOpen = false
+      // A concurrent fast-open probe can win before the server accepts the LAN stream.
+      fastOpen = false
 
       const socket = c.dht.io.serverSocket
       c.dht.ping(addr).then(onlanconnect, onlanerror)

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -223,6 +223,7 @@ async function holepunch(c, opts) {
 
   const remoteHolepunchable = !!(payload.holepunch && payload.holepunch.relays.length)
   const relayed = diffAddress(serverAddress, relayAddress)
+  let fastOpen = opts.fastOpen !== false
 
   if (payload.firewall === FIREWALL.OPEN || (relayed && !remoteHolepunchable)) {
     const addr = getFirstRemoteAddress(payload.addresses4, serverAddress)
@@ -253,7 +254,12 @@ async function holepunch(c, opts) {
 
     if (serverAddresses.length > 0) {
       const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
-      const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
+      const matchedAddress = Holepuncher.matchAddress(myAddresses, serverAddresses)
+      const addr = matchedAddress || serverAddresses[0]
+
+      // An unmatched LAN address can still be reachable, but the concurrent
+      // fast-open probe can win before the server accepts the LAN stream.
+      if (!matchedAddress) fastOpen = false
 
       const socket = c.dht.io.serverSocket
       c.dht.ping(addr).then(onlanconnect, onlanerror)
@@ -290,7 +296,7 @@ async function holepunch(c, opts) {
 
   let probe
   try {
-    probe = await probeRound(c, opts.fastOpen === false ? null : serverAddress, serverRelay, true)
+    probe = await probeRound(c, fastOpen ? serverAddress : null, serverRelay, true)
   } catch (err) {
     destroyPuncher(c)
     // TODO: we should retry here with some of the other relays, bail for now

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -256,7 +256,7 @@ async function holepunch(c, opts) {
       const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
       const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
 
-      // A concurrent fast-open probe can win before the server accepts the LAN stream.
+      // Avoid a premature fast-open win while LAN and coordinated holepunching are racing.
       fastOpen = false
 
       const socket = c.dht.io.serverSocket

--- a/lib/connect.js
+++ b/lib/connect.js
@@ -223,6 +223,7 @@ async function holepunch(c, opts) {
 
   const remoteHolepunchable = !!(payload.holepunch && payload.holepunch.relays.length)
   const relayed = diffAddress(serverAddress, relayAddress)
+  let fastOpen = opts.fastOpen !== false
 
   if (payload.firewall === FIREWALL.OPEN || (relayed && !remoteHolepunchable)) {
     const addr = getFirstRemoteAddress(payload.addresses4, serverAddress)
@@ -254,6 +255,9 @@ async function holepunch(c, opts) {
     if (serverAddresses.length > 0) {
       const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
       const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
+
+      // Do not let the initial probe claim the route before the LAN attempt settles.
+      fastOpen = false
 
       const socket = c.dht.io.serverSocket
       c.dht.ping(addr).then(onlanconnect, onlanerror)
@@ -290,7 +294,7 @@ async function holepunch(c, opts) {
 
   let probe
   try {
-    probe = await probeRound(c, opts.fastOpen === false ? null : serverAddress, serverRelay, true)
+    probe = await probeRound(c, fastOpen ? serverAddress : null, serverRelay, true)
   } catch (err) {
     destroyPuncher(c)
     // TODO: we should retry here with some of the other relays, bail for now

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -123,6 +123,9 @@ module.exports = class Holepuncher {
 
   _onholepunchmessage(_, addr, ref) {
     if (!this.isInitiator) {
+      // Do not echo early probes before this side has committed to coordinated punching.
+      if (!this.punching) return
+
       // TODO: we don't need this if we had a way to connect a socket to many hosts
       holepunch(ref.socket, addr, false) // never fails
       return

--- a/test/connections.js
+++ b/test/connections.js
@@ -298,10 +298,30 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await b.destroy()
 })
 
-test(
-  'createServer + connect - unmatched LAN address skips initial fast-open',
-  { timeout: 10000 },
-  async function (t) {
+for (const testCase of [
+  {
+    name: 'unmatched LAN address skips initial fast-open',
+    matched: false,
+    sameHost: true,
+    expectedLan: true,
+    expectedFastOpen: false
+  },
+  {
+    name: 'matched LAN address skips initial fast-open',
+    matched: true,
+    sameHost: true,
+    expectedLan: true,
+    expectedFastOpen: false
+  },
+  {
+    name: 'different observed hosts keep initial fast-open',
+    matched: true,
+    sameHost: false,
+    expectedLan: false,
+    expectedFastOpen: true
+  }
+]) {
+  test(`createServer + connect - ${testCase.name}`, { timeout: 10000 }, async function (t) {
     const { bootstrap } = await swarm(t, 3)
     const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
     const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
@@ -315,7 +335,10 @@ test(
 
     const matchAddress = Holepuncher.matchAddress
     const openSession = Holepuncher.prototype.openSession
+    const peerHandshake = clientDHT._router.peerHandshake
+    const ping = clientDHT.ping
     const clientPort = clientDHT.io.serverSocket.address().port
+    const serverPort = serverDHT.io.serverSocket.address().port
     let triedLan = false
     let triedHolepunch = false
     let fastOpened = false
@@ -324,10 +347,12 @@ test(
       onholepunch = resolve
     })
 
-    // Inject an unmatched classification instead of relying on whether the
-    // runner can route from loopback to one of its LAN interfaces.
+    // Make the address classification deterministic for the client while
+    // preserving the real server-side classification.
     Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
-      if (localAddresses[0].port === clientPort) return null
+      if (localAddresses[0].port === clientPort) {
+        return testCase.matched ? remoteAddresses[0] : null
+      }
       return matchAddress(localAddresses, remoteAddresses)
     }
 
@@ -339,14 +364,29 @@ test(
       return openSession.call(this, addr, socket)
     }
 
+    clientDHT._router.peerHandshake = async function (...args) {
+      const result = await peerHandshake.apply(this, args)
+      // The local testnet observes loopback for both peers, so inject a
+      // different observation for the non-LAN case.
+      if (!testCase.sameHost) {
+        result.clientAddress = { ...result.clientAddress, host: '127.0.0.2' }
+      }
+      return result
+    }
+
     t.teardown(() => {
       Holepuncher.matchAddress = matchAddress
       Holepuncher.prototype.openSession = openSession
+      clientDHT._router.peerHandshake = peerHandshake
+      clientDHT.ping = ping
     })
 
-    clientDHT.ping = function () {
-      triedLan = true
-      return Promise.reject(new Error('stop LAN probe'))
+    clientDHT.ping = function (addr, ...args) {
+      if (addr.port === serverPort) {
+        triedLan = true
+        return Promise.reject(new Error('stop LAN probe'))
+      }
+      return ping.call(this, addr, ...args)
     }
 
     clientDHT._router.peerHolepunch = async function () {
@@ -360,16 +400,16 @@ test(
 
     await holepunching
 
-    t.ok(triedLan, 'client tried the unmatched LAN fallback')
+    t.is(triedLan, testCase.expectedLan, 'client used the expected LAN policy')
     t.ok(triedHolepunch, 'client started coordinated holepunching')
-    t.absent(fastOpened, 'client skipped the initial fast-open probe')
+    t.is(fastOpened, testCase.expectedFastOpen, 'client used the expected fast-open policy')
 
     socket.destroy()
     await server.close()
     await serverDHT.destroy()
     await clientDHT.destroy()
-  }
-)
+  })
+}
 
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)

--- a/test/connections.js
+++ b/test/connections.js
@@ -6,6 +6,7 @@ const DHT = require('../')
 const NoiseWrap = require('../lib/noise-wrap')
 const { FIREWALL, ERROR } = require('../lib/constants')
 const { unslabbedHash } = require('../lib/crypto')
+const Holepuncher = require('../lib/holepuncher')
 
 test('createServer + connect - once defaults', async function (t) {
   t.plan(2)
@@ -299,6 +300,128 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await a.destroy()
   await b.destroy()
 })
+
+test('createServer + connect - unmatched LAN address skips initial fast-open probe', async function (t) {
+  await runLanFastOpenCase(t, false)
+})
+
+test('createServer + connect - matched LAN address skips initial fast-open probe', async function (t) {
+  await runLanFastOpenCase(t, true)
+})
+
+test('createServer + connect - non-LAN connection preserves intentional server fast-open', async function (t) {
+  const { bootstrap } = await swarm(t, 5)
+  const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  let coordinatedHolepunch = false
+
+  t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+    force: true,
+    order: 1
+  })
+
+  const server = serverDHT.createServer({ shareLocalAddress: false }, function (socket) {
+    socket.on('data', function (data) {
+      socket.end(data)
+    })
+  })
+
+  await server.listen()
+
+  const socket = clientDHT.connect(server.publicKey, {
+    localConnection: false,
+    holepunch() {
+      coordinatedHolepunch = true
+      return true
+    }
+  })
+  socket.end('ping')
+
+  const [data] = await once(socket, 'data')
+  t.alike(data, Buffer.from('ping'))
+  t.is(coordinatedHolepunch, false, 'connected before coordinated holepunching')
+})
+
+async function runLanFastOpenCase(t, matched) {
+  const { bootstrap } = await swarm(t, 3)
+  const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+    force: true,
+    order: 1
+  })
+
+  await serverDHT.fullyBootstrapped()
+  await clientDHT.fullyBootstrapped()
+
+  const server = serverDHT.createServer()
+
+  await server.listen(DHT.keyPair())
+
+  const matchAddress = Holepuncher.matchAddress
+  const openSession = Holepuncher.prototype.openSession
+  const peerHolepunch = clientDHT._router.peerHolepunch
+  const ping = clientDHT.ping
+  const clientPort = clientDHT.io.serverSocket.address().port
+  const serverPort = serverDHT.io.serverSocket.address().port
+  let triedLan = false
+  let sentInitialProbe = false
+  let onholepunch
+  const holepunching = new Promise((resolve) => {
+    onholepunch = resolve
+  })
+
+  // Make the address classification deterministic for the client while
+  // preserving the real server-side classification.
+  Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
+    if (localAddresses[0].port === clientPort) {
+      return matched ? remoteAddresses[0] : null
+    }
+    return matchAddress(localAddresses, remoteAddresses)
+  }
+
+  Holepuncher.prototype.openSession = function (addr, socket) {
+    if (this.dht === clientDHT) {
+      sentInitialProbe = true
+      return Promise.resolve()
+    }
+    return openSession.call(this, addr, socket)
+  }
+
+  t.teardown(
+    () => {
+      Holepuncher.matchAddress = matchAddress
+      Holepuncher.prototype.openSession = openSession
+      clientDHT._router.peerHolepunch = peerHolepunch
+      clientDHT.ping = ping
+    },
+    { force: true, order: -1 }
+  )
+
+  clientDHT.ping = function (addr, ...args) {
+    if (addr.port === serverPort) {
+      triedLan = true
+      return Promise.reject(new Error('stop LAN probe'))
+    }
+    return ping.call(this, addr, ...args)
+  }
+
+  clientDHT._router.peerHolepunch = async function () {
+    onholepunch()
+    throw new Error('stop holepunch probe')
+  }
+
+  const socket = clientDHT.connect(server.publicKey)
+  socket.on('error', () => {})
+
+  await holepunching
+
+  t.ok(triedLan, 'client started the LAN attempt')
+  t.is(sentInitialProbe, false, 'client skipped the initial probe')
+
+  socket.destroy()
+}
 
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)

--- a/test/connections.js
+++ b/test/connections.js
@@ -298,117 +298,105 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await b.destroy()
 })
 
-for (const testCase of [
-  {
-    name: 'unmatched LAN address skips initial fast-open',
-    matched: false,
-    sameHost: true,
-    expectedLan: true,
-    expectedFastOpen: false
-  },
-  {
-    name: 'matched LAN address skips initial fast-open',
-    matched: true,
-    sameHost: true,
-    expectedLan: true,
-    expectedFastOpen: false
-  },
-  {
-    name: 'different observed hosts keep initial fast-open',
-    matched: true,
-    sameHost: false,
-    expectedLan: false,
-    expectedFastOpen: true
-  }
-]) {
-  test(`createServer + connect - ${testCase.name}`, { timeout: 10000 }, async function (t) {
-    const { bootstrap } = await swarm(t, 3)
-    const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
-    const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+test('createServer + connect - unmatched LAN address skips initial fast-open', async function (t) {
+  await runInitialFastOpenCase(t, { matched: false, sameHost: true })
+})
 
-    await serverDHT.fullyBootstrapped()
-    await clientDHT.fullyBootstrapped()
+test('createServer + connect - matched LAN address skips initial fast-open', async function (t) {
+  await runInitialFastOpenCase(t, { matched: true, sameHost: true })
+})
 
-    const server = serverDHT.createServer()
+test('createServer + connect - different observed hosts keep initial fast-open', async function (t) {
+  await runInitialFastOpenCase(t, { matched: true, sameHost: false })
+})
 
-    await server.listen(DHT.keyPair())
+async function runInitialFastOpenCase(t, { matched, sameHost }) {
+  const { bootstrap } = await swarm(t, 3)
+  const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-    const matchAddress = Holepuncher.matchAddress
-    const openSession = Holepuncher.prototype.openSession
-    const peerHandshake = clientDHT._router.peerHandshake
-    const ping = clientDHT.ping
-    const clientPort = clientDHT.io.serverSocket.address().port
-    const serverPort = serverDHT.io.serverSocket.address().port
-    let triedLan = false
-    let triedHolepunch = false
-    let fastOpened = false
-    let onholepunch
-    const holepunching = new Promise((resolve) => {
-      onholepunch = resolve
-    })
+  await serverDHT.fullyBootstrapped()
+  await clientDHT.fullyBootstrapped()
 
-    // Make the address classification deterministic for the client while
-    // preserving the real server-side classification.
-    Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
-      if (localAddresses[0].port === clientPort) {
-        return testCase.matched ? remoteAddresses[0] : null
-      }
-      return matchAddress(localAddresses, remoteAddresses)
-    }
+  const server = serverDHT.createServer()
 
-    Holepuncher.prototype.openSession = function (addr, socket) {
-      if (this.dht === clientDHT) {
-        fastOpened = true
-        return Promise.resolve()
-      }
-      return openSession.call(this, addr, socket)
-    }
+  await server.listen(DHT.keyPair())
 
-    clientDHT._router.peerHandshake = async function (...args) {
-      const result = await peerHandshake.apply(this, args)
-      // The local testnet observes loopback for both peers, so inject a
-      // different observation for the non-LAN case.
-      if (!testCase.sameHost) {
-        result.clientAddress = { ...result.clientAddress, host: '127.0.0.2' }
-      }
-      return result
-    }
-
-    t.teardown(() => {
-      Holepuncher.matchAddress = matchAddress
-      Holepuncher.prototype.openSession = openSession
-      clientDHT._router.peerHandshake = peerHandshake
-      clientDHT.ping = ping
-    })
-
-    clientDHT.ping = function (addr, ...args) {
-      if (addr.port === serverPort) {
-        triedLan = true
-        return Promise.reject(new Error('stop LAN probe'))
-      }
-      return ping.call(this, addr, ...args)
-    }
-
-    clientDHT._router.peerHolepunch = async function () {
-      triedHolepunch = true
-      onholepunch()
-      throw new Error('stop holepunch probe')
-    }
-
-    const socket = clientDHT.connect(server.publicKey)
-    socket.on('error', () => {})
-
-    await holepunching
-
-    t.is(triedLan, testCase.expectedLan, 'client used the expected LAN policy')
-    t.ok(triedHolepunch, 'client started coordinated holepunching')
-    t.is(fastOpened, testCase.expectedFastOpen, 'client used the expected fast-open policy')
-
-    socket.destroy()
-    await server.close()
-    await serverDHT.destroy()
-    await clientDHT.destroy()
+  const matchAddress = Holepuncher.matchAddress
+  const openSession = Holepuncher.prototype.openSession
+  const peerHandshake = clientDHT._router.peerHandshake
+  const ping = clientDHT.ping
+  const clientPort = clientDHT.io.serverSocket.address().port
+  const serverPort = serverDHT.io.serverSocket.address().port
+  let triedLan = false
+  let triedHolepunch = false
+  let fastOpened = false
+  let onholepunch
+  const holepunching = new Promise((resolve) => {
+    onholepunch = resolve
   })
+
+  // Make the address classification deterministic for the client while
+  // preserving the real server-side classification.
+  Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
+    if (localAddresses[0].port === clientPort) {
+      return matched ? remoteAddresses[0] : null
+    }
+    return matchAddress(localAddresses, remoteAddresses)
+  }
+
+  Holepuncher.prototype.openSession = function (addr, socket) {
+    if (this.dht === clientDHT) {
+      fastOpened = true
+      return Promise.resolve()
+    }
+    return openSession.call(this, addr, socket)
+  }
+
+  clientDHT._router.peerHandshake = async function (...args) {
+    const result = await peerHandshake.apply(this, args)
+    // The local testnet observes loopback for both peers, so inject a
+    // different observation for the non-LAN case.
+    if (!sameHost) {
+      result.clientAddress = { ...result.clientAddress, host: '127.0.0.2' }
+    }
+    return result
+  }
+
+  t.teardown(() => {
+    Holepuncher.matchAddress = matchAddress
+    Holepuncher.prototype.openSession = openSession
+    clientDHT._router.peerHandshake = peerHandshake
+    clientDHT.ping = ping
+  })
+
+  clientDHT.ping = function (addr, ...args) {
+    if (addr.port === serverPort) {
+      triedLan = true
+      return Promise.reject(new Error('stop LAN probe'))
+    }
+    return ping.call(this, addr, ...args)
+  }
+
+  clientDHT._router.peerHolepunch = async function () {
+    triedHolepunch = true
+    onholepunch()
+    throw new Error('stop holepunch probe')
+  }
+
+  const socket = clientDHT.connect(server.publicKey)
+  socket.on('error', () => {})
+
+  await holepunching
+
+  t.is(triedLan, sameHost, 'client used the expected LAN policy')
+  t.ok(triedHolepunch, 'client started coordinated holepunching')
+  t.is(fastOpened, !sameHost, 'client used the expected fast-open policy')
+
+  socket.destroy()
+  await server.close()
+  await serverDHT.destroy()
+  await clientDHT.destroy()
 }
 
 test('server choosing to abort holepunch', async function (t) {

--- a/test/connections.js
+++ b/test/connections.js
@@ -3,6 +3,7 @@ const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
 const DHT = require('../')
+const Holepuncher = require('../lib/holepuncher')
 
 test('createServer + connect - once defaults', async function (t) {
   t.plan(2)
@@ -296,6 +297,56 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await a.destroy()
   await b.destroy()
 })
+
+test(
+  'createServer + connect - unmatched LAN address does not false-open',
+  { timeout: 10000 },
+  async function (t) {
+    const { bootstrap } = await swarm(t, 3)
+    const serverDHT = new DHT({ bootstrap })
+    const clientDHT = new DHT({ bootstrap, host: '127.0.0.1' })
+    const lc = t.test('socket lifecycle')
+    let accepted = 0
+    let triedUnmatchedLan = false
+
+    lc.plan(2)
+
+    const server = serverDHT.createServer(function (socket) {
+      accepted++
+      lc.pass('server side opened')
+      socket.once('end', () => socket.end())
+    })
+
+    await server.listen(DHT.keyPair())
+
+    const ping = clientDHT.ping.bind(clientDHT)
+    clientDHT.ping = function (addr, opts) {
+      const localAddresses = Holepuncher.localAddresses(clientDHT.io.serverSocket)
+      if (!Holepuncher.matchAddress(localAddresses, [addr])) triedUnmatchedLan = true
+      return ping(addr, opts)
+    }
+
+    const socket = clientDHT.connect(server.publicKey)
+
+    socket.once('open', function () {
+      lc.pass('client side opened')
+    })
+
+    socket.once('error', function (err) {
+      lc.fail('client should not error: ' + err.code)
+    })
+
+    await lc
+
+    t.ok(triedUnmatchedLan, 'client tried the unmatched LAN fallback')
+    t.is(accepted, 1, 'server accepted exactly once')
+
+    await endAndCloseSocket(socket)
+    await server.close()
+    await serverDHT.destroy()
+    await clientDHT.destroy()
+  }
+)
 
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)

--- a/test/connections.js
+++ b/test/connections.js
@@ -299,49 +299,72 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
 })
 
 test(
-  'createServer + connect - unmatched LAN address does not false-open',
+  'createServer + connect - unmatched LAN address skips initial fast-open',
   { timeout: 10000 },
   async function (t) {
     const { bootstrap } = await swarm(t, 3)
-    const serverDHT = new DHT({ bootstrap })
-    const clientDHT = new DHT({ bootstrap, host: '127.0.0.1' })
-    const lc = t.test('socket lifecycle')
-    let accepted = 0
-    let triedUnmatchedLan = false
+    const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+    const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-    lc.plan(2)
+    await serverDHT.fullyBootstrapped()
+    await clientDHT.fullyBootstrapped()
 
-    const server = serverDHT.createServer(function (socket) {
-      accepted++
-      lc.pass('server side opened')
-      socket.once('end', () => socket.end())
-    })
+    const server = serverDHT.createServer()
 
     await server.listen(DHT.keyPair())
 
-    const ping = clientDHT.ping.bind(clientDHT)
-    clientDHT.ping = function (addr, opts) {
-      const localAddresses = Holepuncher.localAddresses(clientDHT.io.serverSocket)
-      if (!Holepuncher.matchAddress(localAddresses, [addr])) triedUnmatchedLan = true
-      return ping(addr, opts)
+    const matchAddress = Holepuncher.matchAddress
+    const openSession = Holepuncher.prototype.openSession
+    const clientPort = clientDHT.io.serverSocket.address().port
+    let triedLan = false
+    let triedHolepunch = false
+    let fastOpened = false
+    let onholepunch
+    const holepunching = new Promise((resolve) => {
+      onholepunch = resolve
+    })
+
+    // Inject an unmatched classification instead of relying on whether the
+    // runner can route from loopback to one of its LAN interfaces.
+    Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
+      if (localAddresses[0].port === clientPort) return null
+      return matchAddress(localAddresses, remoteAddresses)
+    }
+
+    Holepuncher.prototype.openSession = function (addr, socket) {
+      if (this.dht === clientDHT) {
+        fastOpened = true
+        return Promise.resolve()
+      }
+      return openSession.call(this, addr, socket)
+    }
+
+    t.teardown(() => {
+      Holepuncher.matchAddress = matchAddress
+      Holepuncher.prototype.openSession = openSession
+    })
+
+    clientDHT.ping = function () {
+      triedLan = true
+      return Promise.reject(new Error('stop LAN probe'))
+    }
+
+    clientDHT._router.peerHolepunch = async function () {
+      triedHolepunch = true
+      onholepunch()
+      throw new Error('stop holepunch probe')
     }
 
     const socket = clientDHT.connect(server.publicKey)
+    socket.on('error', () => {})
 
-    socket.once('open', function () {
-      lc.pass('client side opened')
-    })
+    await holepunching
 
-    socket.once('error', function (err) {
-      lc.fail('client should not error: ' + err.code)
-    })
+    t.ok(triedLan, 'client tried the unmatched LAN fallback')
+    t.ok(triedHolepunch, 'client started coordinated holepunching')
+    t.absent(fastOpened, 'client skipped the initial fast-open probe')
 
-    await lc
-
-    t.ok(triedUnmatchedLan, 'client tried the unmatched LAN fallback')
-    t.is(accepted, 1, 'server accepted exactly once')
-
-    await endAndCloseSocket(socket)
+    socket.destroy()
     await server.close()
     await serverDHT.destroy()
     await clientDHT.destroy()

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,6 +1,30 @@
 const test = require('brittle')
 const Holepuncher = require('../lib/holepuncher.js')
 
+test('holepuncher only echoes after local punching starts', function (t) {
+  let sent = 0
+  const puncher = Object.assign(Object.create(Holepuncher.prototype), {
+    isInitiator: false,
+    remoteHolepunching: true,
+    punching: false
+  })
+  const ref = {
+    socket: {
+      send() {
+        sent++
+      }
+    }
+  }
+  const address = { host: '127.0.0.1', port: 1234 }
+
+  puncher._onholepunchmessage(null, address, ref)
+  t.is(sent, 0, 'peer intent alone does not enable echoes')
+
+  puncher.punching = true
+  puncher._onholepunchmessage(null, address, ref)
+  t.is(sent, 1, 'echoes after local punching starts')
+})
+
 test('holepuncher match - nothing to match', async function (t) {
   t.is(Holepuncher.matchAddress([], []), null)
 

--- a/test/integration/same-egress-fast-open.js
+++ b/test/integration/same-egress-fast-open.js
@@ -1,0 +1,75 @@
+const test = require('brittle')
+const { swarm, createDHT } = require('../helpers')
+const Holepuncher = require('../../lib/holepuncher')
+
+test(
+  'same-egress peers preserve fast-open when LAN route fails (CGNAT-like)',
+  { timeout: 15000 },
+  async function (t) {
+    const { bootstrap } = await swarm(t, 5)
+    const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+    const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+    t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+      force: true,
+      order: 1
+    })
+
+    await Promise.all([serverDHT.fullyBootstrapped(), clientDHT.fullyBootstrapped()])
+
+    const serverPort = serverDHT.io.serverSocket.address().port
+    const matchAddress = Holepuncher.matchAddress
+    const ping = clientDHT.ping
+    let lanAttempts = 0
+    let coordinated = false
+
+    // Model distinct peers sharing one public egress IP, as can happen behind
+    // CGNAT. Sharing an external IP does not imply that their private addresses
+    // are mutually reachable, so a failed LAN candidate must not disable an
+    // otherwise viable fast-open route.
+    Holepuncher.matchAddress = () => null
+
+    clientDHT.ping = function (addr, ...args) {
+      if (addr.port === serverPort) {
+        lanAttempts++
+        return Promise.reject(new Error('not actually on the same LAN'))
+      }
+      return ping.call(this, addr, ...args)
+    }
+
+    t.teardown(
+      () => {
+        Holepuncher.matchAddress = matchAddress
+        clientDHT.ping = ping
+      },
+      { force: true, order: -1 }
+    )
+
+    const server = serverDHT.createServer(function (socket) {
+      socket.on('data', (data) => socket.end(data))
+    })
+    await server.listen()
+    t.teardown(() => server.close(), { force: true })
+
+    const socket = clientDHT.connect(server.publicKey, {
+      holepunch() {
+        coordinated = true
+        return false
+      }
+    })
+    t.teardown(() => socket.destroy(), { force: true })
+
+    const outcome = new Promise((resolve) => {
+      socket.once('data', (data) => resolve({ event: 'data', data }))
+      socket.once('error', (err) => resolve({ event: 'error', code: err.code }))
+    })
+
+    socket.end('ping')
+    const result = await outcome
+
+    t.ok(lanAttempts > 0, 'exercised false-LAN path')
+    t.is(coordinated, false, 'fast-open won before coordinated punching')
+    t.is(result.event, 'data', 'connection succeeded through intentional fast-open')
+    if (result.data) t.alike(result.data, Buffer.from('ping'))
+  }
+)


### PR DESCRIPTION
This prevents an initiator from claiming a direct route before the responder has committed to it.

## Changes

- When a LAN attempt starts, skip the speculative initial fast-open probe while the LAN ping and coordinated holepunching continue concurrently.
- On the responder, echo holepunch probes only after local coordinated punching has started. This deliberately checks local `punching`, rather than the initiator's advertised intent.

## Probe ordering

For an older initiator connecting to an updated responder:

| Probe arrival | Responder behavior |
| --- | --- |
| Before any control message | Ignore |
| After the initial `punching: false` message | Ignore |
| After `punching: true`, but before local approval and `p.punch()` | Ignore |
| After local `p.punch()` starts | Echo |

This covers both probe-before-control and control-before-probe ordering. A delayed probe cannot bypass NAT analysis, application rejection, punch rate limits, or an abort. Once local punching has started, the responder has committed and echoing is safe.

There is no wire-format change, and intentional non-LAN server fast-open remains available. Updated responders protect older initiators regardless of probe ordering; older responders retain the existing behavior outside detected LAN attempts until upgraded.

## Validation

- Permanent tests cover matched and fallback LAN candidates, preservation of intentional non-LAN server fast-open, and responder echo behavior before and after local punching.
- Full Node, Bare, and integration suites pass.
- Version-pinned mixed-version evidence against `hyperdht@6.33.1`, including reordered-probe acceptance and rejection, is isolated in draft [#288](https://github.com/holepunchto/hyperdht/pull/288).

Co-authored with AI