### PR TITLE
distinguish fast-open from probe echoes

### DIFF
--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -5,6 +5,7 @@ const { FIREWALL } = require('./constants')
 
 const BIRTHDAY_SOCKETS = 256
 const HOLEPUNCH = b4a.from([0])
+const FAST_OPEN = b4a.from([1])
 const HOLEPUNCH_TTL = 5
 const DEFAULT_TTL = 64
 const MAX_REOPENS = 3
@@ -78,6 +79,10 @@ module.exports = class Holepuncher {
     return holepunch(socket, addr, false)
   }
 
+  fastOpen(addr, socket = this._holder.socket) {
+    return holepunch(socket, addr, false, FAST_OPEN)
+  }
+
   openSession(addr, socket = this._holder.socket) {
     return holepunch(socket, addr, true)
   }
@@ -121,14 +126,21 @@ module.exports = class Holepuncher {
     return ref
   }
 
-  _onholepunchmessage(_, addr, ref) {
+  _onholepunchmessage(message, addr, ref) {
     if (!this.isInitiator) {
+      if (!this.remoteHolepunching) return
+
       // TODO: we don't need this if we had a way to connect a socket to many hosts
       holepunch(ref.socket, addr, false) // never fails
       return
     }
 
     if (this.connected) return
+
+    // A probe echo can arrive before the responder has finished analyzing its
+    // NAT. Until punching starts, only let its post-analysis fast-open signal
+    // select the socket.
+    if (!this.punching && !b4a.equals(message, FAST_OPEN)) return
 
     this.connected = true
     this.punching = false
@@ -322,8 +334,8 @@ module.exports = class Holepuncher {
   }
 }
 
-function holepunch(socket, addr, lowTTL) {
-  return socket.send(HOLEPUNCH, addr.port, addr.host, lowTTL ? HOLEPUNCH_TTL : DEFAULT_TTL)
+function holepunch(socket, addr, lowTTL, message = HOLEPUNCH) {
+  return socket.send(message, addr.port, addr.host, lowTTL ? HOLEPUNCH_TTL : DEFAULT_TTL)
 }
 
 function randomPort() {

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -128,7 +128,10 @@ module.exports = class Holepuncher {
 
   _onholepunchmessage(message, addr, ref) {
     if (!this.isInitiator) {
-      if (!this.remoteHolepunching) return
+      // Echo only after local punching has started. Local commitment, not the
+      // initiator's advertised intent, gates the echo so a delayed probe cannot
+      // bypass NAT analysis, application rejection, punch limits, or an abort.
+      if (!this.punching) return
 
       // TODO: we don't need this if we had a way to connect a socket to many hosts
       holepunch(ref.socket, addr, false) // never fails
@@ -178,8 +181,6 @@ module.exports = class Holepuncher {
   async _punch() {
     if (this._done() || !this.remoteAddresses.length) return false
 
-    this.punching = true
-
     // Coerce into consistency for now. Obvs we could make this this more efficient if we use that info
     // but that's seldomly used since those will just use tcp most of the time.
 
@@ -197,7 +198,10 @@ module.exports = class Holepuncher {
       }
     }
 
+    // punching gates probe echoes and pre-punch claims, so it is only set once
+    // a strategy below actually starts probing.
     if (local === FIREWALL.CONSISTENT && remote === FIREWALL.CONSISTENT) {
+      this.punching = true
       this.dht.stats.punches.consistent++
       this._consistentProbe()
       return true
@@ -206,6 +210,7 @@ module.exports = class Holepuncher {
     if (!remoteVerifiedAddress) return false
 
     if (local === FIREWALL.CONSISTENT && remote >= FIREWALL.RANDOM) {
+      this.punching = true
       this.dht.stats.punches.random++
       this._incrementRandomized()
       this._randomProbes(remoteVerifiedAddress)
@@ -213,6 +218,7 @@ module.exports = class Holepuncher {
     }
 
     if (local >= FIREWALL.RANDOM && remote === FIREWALL.CONSISTENT) {
+      this.punching = true
       this.dht.stats.punches.random++
       this._incrementRandomized()
       await this._openBirthdaySockets(remoteVerifiedAddress)

--- a/lib/server.js
+++ b/lib/server.js
@@ -556,13 +556,14 @@ module.exports = class Server extends EventEmitter {
     }
 
     // Fast mode! If we are consistent and the remote has opened a session to us (remoteAddress)
-    // then fire a quick punch back. Note the await here just waits for the udp socket to flush.
+    // then confirm fast-open from the analyzed socket. Note the await here just waits for the udp
+    // socket to flush.
     if (
       isConsistent(p.nat.firewall) &&
       remoteAddress &&
       hasSameAddr(p.nat.addresses, remoteAddress)
     ) {
-      await p.ping(peerAddress)
+      await p.fastOpen(peerAddress)
       if (p.destroyed) return null
     }
 

--- a/test/connections.js
+++ b/test/connections.js
@@ -184,6 +184,53 @@ test('createServer + connect - force holepunch', async function (t) {
   await b.destroy()
 })
 
+test('createServer + connect - cold local fast-open uses analyzed socket', async function (t) {
+  const { bootstrap } = await swarm(t, 3)
+
+  // Deliberately connect before either endpoint is fully bootstrapped. The
+  // explicit client host reproduces the asymmetric local-address setup where
+  // a probe echo used to select a socket that the server later discarded.
+  const serverDHT = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = new DHT({
+    bootstrap,
+    host: '127.0.0.1',
+    quickFirewall: false,
+    ephemeral: true
+  })
+
+  const lc = t.test('socket lifecycle')
+  lc.plan(4)
+
+  const server = serverDHT.createServer(function (socket) {
+    lc.pass('server side opened')
+
+    socket.once('end', function () {
+      lc.pass('server side ended')
+      socket.end()
+    })
+  })
+
+  await server.listen()
+
+  const socket = clientDHT.connect(server.publicKey)
+
+  socket.once('open', function () {
+    lc.pass('client side opened')
+  })
+
+  socket.once('end', function () {
+    lc.pass('client side ended')
+  })
+
+  socket.end()
+
+  await lc
+
+  await server.close()
+  await serverDHT.destroy()
+  await clientDHT.destroy()
+})
+
 test('createServer + connect - failed LAN ping falls back to holepunch', async function (t) {
   const { bootstrap } = await swarm(t)
 

--- a/test/connections.js
+++ b/test/connections.js
@@ -3,6 +3,7 @@ const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
 const DHT = require('../')
+const Holepuncher = require('../lib/holepuncher')
 const NoiseWrap = require('../lib/noise-wrap')
 const { FIREWALL, ERROR } = require('../lib/constants')
 const { unslabbedHash } = require('../lib/crypto')
@@ -241,6 +242,95 @@ test('createServer + connect - cold fast-open precedes coordinated punching', as
   await serverDHT.destroy()
   await clientDHT.destroy()
 })
+
+test(
+  'same-egress peers preserve fast-open when LAN route fails (CGNAT-like)',
+  { timeout: 15000 },
+  async function (t) {
+    const { bootstrap } = await swarm(t, 5)
+    const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+    const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+    t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+      force: true,
+      order: 1
+    })
+
+    await Promise.all([serverDHT.fullyBootstrapped(), clientDHT.fullyBootstrapped()])
+
+    const serverPort = serverDHT.io.serverSocket.address().port
+    const matchAddress = Holepuncher.matchAddress
+    const fastOpen = Holepuncher.prototype.fastOpen
+    const ping = clientDHT.ping
+    let lanAttempts = 0
+    let fastOpenAttempts = 0
+    let coordinated = false
+
+    // Model distinct peers sharing one public egress IP, as can happen behind
+    // CGNAT. Sharing an external IP does not imply that their private addresses
+    // are mutually reachable, so a failed LAN candidate must not disable an
+    // otherwise viable fast-open route.
+    Holepuncher.matchAddress = () => null
+
+    // Fast-open is deliberately one best-effort datagram in production. Repeat
+    // it only in this test so route-policy coverage does not hinge on one packet.
+    Holepuncher.prototype.fastOpen = function (...args) {
+      if (this.dht !== serverDHT) return fastOpen.apply(this, args)
+
+      fastOpenAttempts++
+      return Promise.all([
+        fastOpen.apply(this, args),
+        fastOpen.apply(this, args),
+        fastOpen.apply(this, args)
+      ])
+    }
+
+    clientDHT.ping = function (addr, ...args) {
+      if (addr.port === serverPort) {
+        lanAttempts++
+        return Promise.reject(new Error('not actually on the same LAN'))
+      }
+      return ping.call(this, addr, ...args)
+    }
+
+    t.teardown(
+      () => {
+        Holepuncher.matchAddress = matchAddress
+        Holepuncher.prototype.fastOpen = fastOpen
+        clientDHT.ping = ping
+      },
+      { force: true, order: -1 }
+    )
+
+    const server = serverDHT.createServer(function (socket) {
+      socket.on('data', (data) => socket.end(data))
+    })
+    await server.listen()
+    t.teardown(() => server.close(), { force: true })
+
+    const socket = clientDHT.connect(server.publicKey, {
+      holepunch() {
+        coordinated = true
+        return false
+      }
+    })
+    t.teardown(() => socket.destroy(), { force: true })
+
+    const outcome = new Promise((resolve) => {
+      socket.once('data', (data) => resolve({ event: 'data', data }))
+      socket.once('error', (err) => resolve({ event: 'error', code: err.code }))
+    })
+
+    socket.end('ping')
+    const result = await outcome
+
+    t.ok(lanAttempts > 0, 'exercised false-LAN path')
+    t.ok(fastOpenAttempts > 0, 'responder attempted intentional fast-open')
+    t.is(coordinated, false, 'fast-open won before coordinated punching')
+    t.is(result.event, 'data', 'connection succeeded through intentional fast-open')
+    if (result.data) t.alike(result.data, Buffer.from('ping'))
+  }
+)
 
 test('createServer + connect - failed LAN ping falls back to holepunch', async function (t) {
   const { bootstrap } = await swarm(t)

--- a/test/connections.js
+++ b/test/connections.js
@@ -184,14 +184,14 @@ test('createServer + connect - force holepunch', async function (t) {
   await b.destroy()
 })
 
-test('createServer + connect - cold local fast-open uses analyzed socket', async function (t) {
+test('createServer + connect - cold fast-open precedes coordinated punching', async function (t) {
   // Holepuncher NAT analysis needs four samples. Keep the endpoints cold, but
   // provide enough local nodes for that analysis to complete deterministically.
   const { bootstrap } = await swarm(t, 5)
 
-  // Deliberately connect before either endpoint is fully bootstrapped. The
-  // explicit client host reproduces the asymmetric local-address setup where
-  // a probe echo used to select a socket that the server later discarded.
+  // Deliberately connect before either endpoint is fully bootstrapped. Disable
+  // local connection attempts so only the server's analyzed fast-open path can
+  // open the connection before coordinated punching starts.
   const serverDHT = new DHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const clientDHT = new DHT({
     bootstrap,

--- a/test/connections.js
+++ b/test/connections.js
@@ -185,7 +185,9 @@ test('createServer + connect - force holepunch', async function (t) {
 })
 
 test('createServer + connect - cold local fast-open uses analyzed socket', async function (t) {
-  const { bootstrap } = await swarm(t, 3)
+  // Holepuncher NAT analysis needs four samples. Keep the endpoints cold, but
+  // provide enough local nodes for that analysis to complete deterministically.
+  const { bootstrap } = await swarm(t, 5)
 
   // Deliberately connect before either endpoint is fully bootstrapped. The
   // explicit client host reproduces the asymmetric local-address setup where
@@ -199,9 +201,11 @@ test('createServer + connect - cold local fast-open uses analyzed socket', async
   })
 
   const lc = t.test('socket lifecycle')
-  lc.plan(4)
+  lc.plan(5)
 
-  const server = serverDHT.createServer(function (socket) {
+  let coordinatedPunching = false
+
+  const server = serverDHT.createServer({ shareLocalAddress: false }, function (socket) {
     lc.pass('server side opened')
 
     socket.once('end', function () {
@@ -212,10 +216,17 @@ test('createServer + connect - cold local fast-open uses analyzed socket', async
 
   await server.listen()
 
-  const socket = clientDHT.connect(server.publicKey)
+  const socket = clientDHT.connect(server.publicKey, {
+    localConnection: false,
+    holepunch() {
+      coordinatedPunching = true
+      return true
+    }
+  })
 
   socket.once('open', function () {
     lc.pass('client side opened')
+    lc.is(coordinatedPunching, false, 'client fast-opened before coordinated punching')
   })
 
   socket.once('end', function () {

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,5 +1,81 @@
 const test = require('brittle')
+const b4a = require('b4a')
 const Holepuncher = require('../lib/holepuncher.js')
+const { FIREWALL } = require('../lib/constants.js')
+
+test('holepuncher distinguishes probe echoes from fast-open', function (t) {
+  const probe = createInitiator()
+  probe.puncher._onholepunchmessage(b4a.from([0]), probe.address, probe.ref)
+  t.is(probe.puncher.connected, false, 'probe echo does not connect before punching')
+  probe.puncher.destroy()
+
+  const fastOpen = createInitiator()
+  fastOpen.puncher._onholepunchmessage(b4a.from([1]), fastOpen.address, fastOpen.ref)
+  t.is(fastOpen.puncher.connected, true, 'explicit fast-open connects before punching')
+  t.alike(fastOpen.connected, fastOpen.address, 'fast-open selects the responding address')
+  fastOpen.puncher.destroy()
+
+  const punching = createInitiator()
+  punching.puncher.punching = true
+  punching.puncher._onholepunchmessage(b4a.from([0]), punching.address, punching.ref)
+  t.is(punching.puncher.connected, true, 'probe echo connects while punching')
+  t.alike(punching.connected, punching.address, 'punching selects the responding address')
+  punching.puncher.destroy()
+})
+
+test('holepuncher only echoes after the remote starts punching', function (t) {
+  const sent = []
+  const responder = createHolepuncher(false, sent)
+
+  responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
+  t.is(sent.length, 0, 'uncommitted probe is not echoed')
+
+  responder.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.UNKNOWN,
+    addresses: null,
+    verified: null
+  })
+  responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
+  t.is(sent.length, 1, 'coordinated punch is echoed')
+
+  responder.puncher.destroy()
+})
+
+function createInitiator() {
+  return createHolepuncher(true, [])
+}
+
+function createHolepuncher(isInitiator, sent) {
+  const socket = {
+    send(message, port, host, ttl) {
+      sent.push({ message, port, host, ttl })
+      return Promise.resolve()
+    }
+  }
+  const ref = { socket, release() {} }
+  const dht = {
+    firewalled: false,
+    nodes: { length: 0, latest: null },
+    _socketPool: { acquire: () => ref }
+  }
+  const puncher = new Holepuncher(dht, {}, isInitiator)
+  const address = { host: '127.0.0.1', port: 1234 }
+  let connected = null
+
+  puncher.onconnect = function (_, port, host) {
+    connected = { host, port }
+  }
+
+  return {
+    puncher,
+    ref,
+    address,
+    get connected() {
+      return connected
+    }
+  }
+}
 
 test('holepuncher match - nothing to match', async function (t) {
   t.is(Holepuncher.matchAddress([], []), null)

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,7 +1,6 @@
 const test = require('brittle')
 const b4a = require('b4a')
 const Holepuncher = require('../lib/holepuncher.js')
-const { FIREWALL } = require('../lib/constants.js')
 
 test('holepuncher distinguishes probe echoes from fast-open', function (t) {
   const probe = createInitiator()
@@ -24,35 +23,53 @@ test('holepuncher distinguishes probe echoes from fast-open', function (t) {
 })
 
 test('holepuncher only echoes after the remote starts punching', function (t) {
-  const sent = []
-  const responder = createHolepuncher(false, sent)
+  const responder = createHolepuncher(false)
 
   responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
-  t.is(sent.length, 0, 'uncommitted probe is not echoed')
+  t.is(responder.sent.length, 0, 'uncommitted probe is not echoed')
 
-  responder.puncher.updateRemote({
-    punching: true,
-    firewall: FIREWALL.UNKNOWN,
-    addresses: null,
-    verified: null
-  })
+  responder.puncher.updateRemote({ punching: true })
   responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
-  t.is(sent.length, 1, 'coordinated punch is echoed')
+  t.is(responder.sent.length, 1, 'coordinated punch is echoed')
 
   responder.puncher.destroy()
 })
 
+test('holepuncher fast-open uses supplied socket', async function (t) {
+  const held = []
+  const sent = []
+  const { puncher, address } = createHolepuncher(true, held)
+
+  await puncher.fastOpen(address, createSocket(sent))
+
+  t.alike(held, [], 'held socket is not used')
+  t.alike(sent, [
+    {
+      message: b4a.from([1]),
+      port: address.port,
+      host: address.host,
+      ttl: 64
+    }
+  ])
+
+  puncher.destroy()
+})
+
 function createInitiator() {
-  return createHolepuncher(true, [])
+  return createHolepuncher(true)
 }
 
-function createHolepuncher(isInitiator, sent) {
-  const socket = {
+function createSocket(sent) {
+  return {
     send(message, port, host, ttl) {
       sent.push({ message, port, host, ttl })
       return Promise.resolve()
     }
   }
+}
+
+function createHolepuncher(isInitiator, sent = []) {
+  const socket = createSocket(sent)
   const ref = { socket, release() {} }
   const dht = {
     firewalled: false,
@@ -71,6 +88,7 @@ function createHolepuncher(isInitiator, sent) {
     puncher,
     ref,
     address,
+    sent,
     get connected() {
       return connected
     }

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,6 +1,7 @@
 const test = require('brittle')
 const b4a = require('b4a')
 const Holepuncher = require('../lib/holepuncher.js')
+const { FIREWALL } = require('../lib/constants.js')
 
 test('holepuncher distinguishes probe echoes from fast-open', function (t) {
   const probe = createInitiator()
@@ -22,7 +23,7 @@ test('holepuncher distinguishes probe echoes from fast-open', function (t) {
   punching.puncher.destroy()
 })
 
-test('holepuncher only echoes after the remote starts punching', function (t) {
+test('holepuncher only echoes after local punching starts', function (t) {
   const responder = createHolepuncher(false)
 
   responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
@@ -30,9 +31,95 @@ test('holepuncher only echoes after the remote starts punching', function (t) {
 
   responder.puncher.updateRemote({ punching: true })
   responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
-  t.is(responder.sent.length, 1, 'coordinated punch is echoed')
+  t.is(responder.sent.length, 0, 'peer intent alone does not enable echoes')
+
+  responder.puncher.punching = true
+  responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
+  t.is(responder.sent.length, 1, 'echoes after local punching starts')
 
   responder.puncher.destroy()
+})
+
+test('holepuncher punch refusal does not mark punching or echo', async function (t) {
+  const responder = createHolepuncher(false)
+
+  responder.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.RANDOM,
+    addresses: [{ host: '127.0.0.1', port: 4321 }],
+    verified: null
+  })
+
+  t.is(await responder.puncher.punch(), false, 'no verified address refuses to punch')
+  t.is(responder.puncher.punching, false, 'refused punch does not mark punching')
+
+  responder.puncher._onholepunchmessage(b4a.from([0]), responder.address, responder.ref)
+  t.is(responder.sent.length, 0, 'refused puncher does not echo')
+
+  responder.puncher.destroy()
+
+  const fallthrough = createHolepuncher(false)
+
+  fallthrough.puncher.nat.firewall = FIREWALL.RANDOM
+  fallthrough.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.RANDOM,
+    addresses: [{ host: '127.0.0.1', port: 4321 }],
+    verified: '127.0.0.1'
+  })
+
+  t.is(await fallthrough.puncher.punch(), false, 'double random refuses to punch')
+  t.is(fallthrough.puncher.punching, false, 'refused punch does not mark punching')
+
+  fallthrough.puncher.destroy()
+})
+
+test('holepuncher punch marks punching for each strategy', async function (t) {
+  const consistent = createHolepuncher(false)
+
+  consistent.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.CONSISTENT,
+    addresses: [{ host: '127.0.0.1', port: 4321 }],
+    verified: null
+  })
+
+  t.is(await consistent.puncher.punch(), true, 'consistent/consistent punches')
+  t.is(consistent.puncher.punching, true, 'consistent/consistent marks punching')
+
+  consistent.puncher._onholepunchmessage(b4a.from([0]), consistent.address, consistent.ref)
+  t.is(consistent.sent.length, 1, 'punching puncher echoes')
+
+  consistent.puncher.destroy()
+
+  const random = createHolepuncher(false)
+
+  random.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.RANDOM,
+    addresses: [{ host: '127.0.0.1', port: 4321 }],
+    verified: '127.0.0.1'
+  })
+
+  t.is(await random.puncher.punch(), true, 'consistent/random punches')
+  t.is(random.puncher.punching, true, 'consistent/random marks punching')
+
+  random.puncher.destroy()
+
+  const birthday = createHolepuncher(false)
+
+  birthday.puncher.nat.firewall = FIREWALL.RANDOM
+  birthday.puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.CONSISTENT,
+    addresses: [{ host: '127.0.0.1', port: 4321 }],
+    verified: '127.0.0.1'
+  })
+
+  t.is(await birthday.puncher.punch(), true, 'random/consistent punches')
+  t.is(birthday.puncher.punching, true, 'random/consistent marks punching')
+
+  birthday.puncher.destroy()
 })
 
 test('holepuncher fast-open uses supplied socket', async function (t) {
@@ -74,6 +161,8 @@ function createHolepuncher(isInitiator, sent = []) {
   const dht = {
     firewalled: false,
     nodes: { length: 0, latest: null },
+    stats: { punches: { consistent: 0, random: 0, open: 0 } },
+    _randomPunches: 0,
     _socketPool: { acquire: () => ref }
   }
   const puncher = new Holepuncher(dht, {}, isInitiator)


### PR DESCRIPTION
Fast-open confirmations and ordinary UDP probe/punch packets both used `[0]`. A delayed probe echo could therefore select the initiator’s socket before the responder committed, racing NAT analysis, server policy, aborts, or another viable route.

## Change

- Keep `[0]` for probes and coordinated punching.
- Use `[1]` for explicit fast-open from the responder’s analyzed socket.
- Before local punching, the initiator accepts only `[1]`; while punching, it also accepts `[0]`.
- The responder echoes probes only after its local strategy starts.
- Refused or unsupported strategies leave `punching` false.

The responder starts punching before replying; the initiator starts after receiving that reply, so local-state echo gating cannot deadlock. Loss of the best-effort `[1]` packet falls back to coordinated punching.

## Compatibility

Old initiators accept `[1]`. A new initiator with an old responder ignores the legacy `[0]` fast-open and falls back to coordinated punching; it can fail if coordinated punching is unavailable.

## Tests

Covers packet discrimination, local commitment gating, refusal and strategy states, cold fast-open, and CGNAT-like same-egress fallback when the LAN candidate fails.