### PR TITLE
Dont use fast-open probes as success before holepunching

### DIFF
--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -131,6 +131,7 @@ module.exports = class Holepuncher {
     if (this.connected) return
 
     this.connected = true
+    if (!this.punching) return
     this.punching = false
 
     for (const r of this._allHolders) {

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -130,8 +130,9 @@ module.exports = class Holepuncher {
 
     if (this.connected) return
 
-    this.connected = true
     if (!this.punching) return
+
+    this.connected = true
     this.punching = false
 
     for (const r of this._allHolders) {


### PR DESCRIPTION
Its possible for a 'fast-open' probe to actually get to the server and it sends a packet back in low ttl networks. This causes a received packet from the server for the probe to be seen as a successful connection when the server doesn't think we are holepunching yet so never registers that as a success.