### PR TITLE
Add test coverage & clean up handshakes received when suspended & reorder clearing

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -449,7 +449,10 @@ module.exports = class Server extends EventEmitter {
       }
     }
 
-    if (this._closing || this.suspended) return null
+    if (this._closing || this.suspended) {
+      this._clearLater(hs, id, k)
+      return null
+    }
 
     if (ourRemoteAddr || this._neverPunch) {
       hs.prepunching = setTimeout(onabort, HANDSHAKE_INITIAL_TIMEOUT)

--- a/lib/server.js
+++ b/lib/server.js
@@ -254,7 +254,10 @@ module.exports = class Server extends EventEmitter {
       return null
     }
 
-    if (this._closing || this.suspended) return null
+    if (this._closing || this.suspended) {
+      this._clearLater(hs, id, k)
+      return null
+    }
 
     try {
       hs.firewalled = await this.firewall(handshake.remotePublicKey, remotePayload, clientAddress)
@@ -262,9 +265,7 @@ module.exports = class Server extends EventEmitter {
       safetyCatch(err)
     }
 
-    if (this._closing || this.suspended) return null
-
-    if (hs.firewalled) {
+    if (this._closing || this.suspended || hs.firewalled) {
       this._clearLater(hs, id, k)
       return null
     }
@@ -280,7 +281,10 @@ module.exports = class Server extends EventEmitter {
     const ourRemoteAddr = this.dht.remoteAddress()
     const ourLocalAddrs = this._shareLocalAddress ? await this._localAddresses() : null
 
-    if (this._closing || this.suspended) return null
+    if (this._closing || this.suspended) {
+      this._clearLater(hs, id, k)
+      return null
+    }
 
     if (ourRemoteAddr) addresses.push(ourRemoteAddr)
     if (ourLocalAddrs) addresses.push(...ourLocalAddrs)
@@ -389,6 +393,7 @@ module.exports = class Server extends EventEmitter {
 
     if (this._closing || this.suspended) {
       if (hs.rawStream) hs.rawStream.destroy()
+      this._clearLater(hs, id, k)
       return null
     }
 

--- a/lib/server.js
+++ b/lib/server.js
@@ -474,7 +474,6 @@ module.exports = class Server extends EventEmitter {
   }
 
   _clear(hs, id, k) {
-    this._connects.delete(k)
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
 
@@ -485,6 +484,7 @@ module.exports = class Server extends EventEmitter {
     ) {
       this._holepunches.pop()
     }
+    this._connects.delete(k)
   }
 
   async _onpeerhandshake({ noise, peerAddress }, req) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -471,6 +471,7 @@ module.exports = class Server extends EventEmitter {
   }
 
   _clear(hs, id, k) {
+    this._connects.delete(k)
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
 
@@ -481,7 +482,6 @@ module.exports = class Server extends EventEmitter {
     ) {
       this._holepunches.pop()
     }
-    this._connects.delete(k)
   }
 
   async _onpeerhandshake({ noise, peerAddress }, req) {

--- a/test/connections.js
+++ b/test/connections.js
@@ -977,3 +977,51 @@ test('peer cant flood w/ handshakes', async function (t) {
   rawStream.destroy()
   await server.close()
 })
+
+test('a handshake that arrives while the server is already suspended leaks forever', async function (t) {
+  const [a] = await swarm(t)
+
+  const handshakeClearWait = 100
+  const server = a.createServer({ handshakeClearWait }, () => {})
+  await server.listen()
+  t.teardown(() => server.close())
+
+  t.is(server._connects.size, 0, 'server starts w/ 0 connections')
+  t.is(server._holepunches.length, 0, 'server starts w/ 0 holepunches')
+
+  // Suspend server so incomming PEER_HANDSHAKEs bail in `_addHandshake()`
+  await server.suspend()
+
+  const handshake = new NoiseWrap(a.defaultKeyPair, server.publicKey)
+  const noise = await handshake.send({
+    error: ERROR.NONE,
+    firewall: FIREWALL.UNKNOWN,
+    holepunch: null,
+    addresses4: [],
+    addresses6: [],
+    udx: { reusableSocket: false, id: 0, seq: 0 },
+    secretStream: {},
+    relayThrough: null
+  })
+
+  const fakePeerAddress = { host: '203.0.113.5', port: 12345 } // unroutable
+  const req = { to: server.address(), from: fakePeerAddress, socket: null }
+
+  const reply = await server._onpeerhandshake({ noise, peerAddress: fakePeerAddress }, req)
+
+  t.absent(reply, 'sanity: the suspended server did not reply to the handshake')
+  t.is(
+    server._connects.size,
+    1,
+    'sanity: _addHandshake still registered itself despite being suspended'
+  )
+  t.is(server._holepunches.length, 1, 'sanity: ... and claimed a holepunch slot for it too')
+
+  // Wait for handshakeClearWait timeout
+  await new Promise((resolve) => setTimeout(resolve, handshakeClearWait + 100))
+
+  await server.resume()
+
+  t.is(server._connects.size, 0, 'the handshake entry should eventually be cleaned up')
+  t.is(server._holepunches.length, 0, '... and so should the holepunch slot')
+})

--- a/test/connections.js
+++ b/test/connections.js
@@ -3,6 +3,9 @@ const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
 const DHT = require('../')
+const NoiseWrap = require('../lib/noise-wrap')
+const { FIREWALL, ERROR } = require('../lib/constants')
+const { unslabbedHash } = require('../lib/crypto')
 
 test('createServer + connect - once defaults', async function (t) {
   t.plan(2)
@@ -929,4 +932,48 @@ test('create server with handshakeClearWait opt', async function (t) {
     const server = a.createServer({})
     t.is(server.handshakeClearWait, 10000, 'expected default')
   }
+})
+
+test('peer cant flood w/ handshakes', async function (t) {
+  const [a, b] = await swarm(t, 2)
+  const server = a.createServer()
+  await server.listen()
+
+  t.is(server._connects.size, 0, 'server starts w/ 0 connections')
+  t.is(server._holepunches.length, 0, 'server starts w/ 0 holepunches')
+
+  // Create a single noise handshake to reuse across many requests
+  const handshake = new NoiseWrap(b.defaultKeyPair, server.publicKey)
+  const rawStream = b.createRawStream({ framed: true, firewall: () => false })
+  const noise = await handshake.send({
+    error: ERROR.NONE,
+    firewall: FIREWALL.UNKNOWN,
+    holepunch: null,
+    addresses4: [],
+    addresses6: [],
+    udx: {
+      reusableSocket: false,
+      id: rawStream.id,
+      seq: 0
+    },
+    secretStream: {},
+    relayThrough: null
+  })
+
+  const target = unslabbedHash(server.publicKey)
+  const to = { host: server.address().host, port: server.address().port }
+
+  const totalRequests = 10
+  const requests = []
+  for (let i = 0; i < totalRequests; i++) {
+    requests.push(b._router.peerHandshake(target, { noise, socket: null }, to))
+  }
+
+  await Promise.all(requests)
+
+  t.is(server._connects.size, 1, 'server only registered 1 connect')
+  t.is(server._holepunches.length, 1, 'server only registered 1 holepunch')
+
+  rawStream.destroy()
+  await server.close()
 })

--- a/test/connections.js
+++ b/test/connections.js
@@ -994,7 +994,7 @@ test('peer cant flood w/ handshakes', async function (t) {
   await server.close()
 })
 
-test('a handshake that arrives while the server is already suspended leaks forever', async function (t) {
+test('handshakes that arrive while the server is suspended are cleared', async function (t) {
   const [a] = await swarm(t)
 
   const handshakeClearWait = 100

--- a/test/connections.js
+++ b/test/connections.js
@@ -934,6 +934,22 @@ test('create server with handshakeClearWait opt', async function (t) {
   }
 })
 
+test('_clear deletes the _connects entry even when the slot was reused', async function (t) {
+  const [a] = await swarm(t)
+  const server = a.createServer()
+  await server.listen()
+
+  const hs = { clearing: null }
+  const k = 'aabbcc'
+  server._connects.set(k, Promise.resolve(hs))
+  server._holepunches[0] = { not: hs } // slot reused by another handshake
+
+  server._clear(hs, 0, k)
+
+  t.is(server._connects.has(k), false, 'k removed despite stale slot')
+  await server.close()
+})
+
 test('peer cant flood w/ handshakes', async function (t) {
   const [a, b] = await swarm(t, 2)
   const server = a.createServer()

--- a/test/connections.js
+++ b/test/connections.js
@@ -934,22 +934,6 @@ test('create server with handshakeClearWait opt', async function (t) {
   }
 })
 
-test('_clear deletes the _connects entry even when the slot was reused', async function (t) {
-  const [a] = await swarm(t)
-  const server = a.createServer()
-  await server.listen()
-
-  const hs = { clearing: null }
-  const k = 'aabbcc'
-  server._connects.set(k, Promise.resolve(hs))
-  server._holepunches[0] = { not: hs } // slot reused by another handshake
-
-  server._clear(hs, 0, k)
-
-  t.is(server._connects.has(k), false, 'k removed despite stale slot')
-  await server.close()
-})
-
 test('peer cant flood w/ handshakes', async function (t) {
   const [a, b] = await swarm(t, 2)
   const server = a.createServer()


### PR DESCRIPTION
This PR came from explorations around potential memory leaks. It includes the following:

1. Added a test for guard against peer flooding a server with handshakes messages. Test called `peer cant flood w/ handshakes`
2. Reorder deleting `._connects.delete(k)` to before clearing holepunch entry.  
   Not required but is clearer that it always is cleared now and that a holepunch entry missing can't leak `_connects` though it was never observed to do so.
3. Add test & protect against leaking `_holepunches` entries when received during closing or being suspended. Test called `handshakes that arrive while the server is suspended are cleared`

`_clear deletes the _connects entry even when the slot was reused` credited to @HDegroote for writing.