### PR TITLE
Create two test cases for replicating an OPEN peer w/o addresses issue

### DIFF
--- a/test/connections.js
+++ b/test/connections.js
@@ -297,6 +297,79 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await b.destroy()
 })
 
+// NOTE This recreates a scenario when the NAT sampler on a remote server can flip OPEN but not report addresses causing the holepunch to abort.
+test.solo(
+  'createServer + connect - remote reports OPEN firewall with no addresses, holepunch fails',
+  async function (t) {
+    const [boot] = await swarm(t)
+
+    const bootstrap = [{ host: '127.0.0.1', port: boot.address().port }]
+    const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+    const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+    await a.fullyBootstrapped()
+    await b.fullyBootstrapped()
+
+    // Force the server (a) into the exact state that produces
+    // "firewall: OPEN, addresses: null" on a real PEER_HOLEPUNCH round:
+    //  - firewalled = false makes its Nat start at FIREWALL.OPEN immediately
+    //    (nat.js: this.firewall = dht.firewalled ? UNKNOWN : OPEN)
+    //  - remoteAddress() returning null removes both the initial-handshake
+    //    fast path (server.js's ourRemoteAddr)
+    //  - blocking session().ping() stops the background NAT auto-sampler
+    //    from ever landing a sample that would otherwise backfill
+    //    nat.addresses and mask the bug
+    a.firewalled = false
+    a.remoteAddress = () => null
+
+    const session = a.session.bind(a)
+    a.session = function () {
+      const s = session()
+      s.ping = () => {
+        console.trace('tried pinging')
+        return Promise.reject(new Error('nat sampling disabled for test'))
+      }
+      return s
+    }
+
+    const lc = t.test('socket lifecycle')
+    lc.plan(3)
+
+    const server = a.createServer({ shareLocalAddress: false }, function () {
+      lc.fail('server should not make a connection')
+    })
+
+    await server.listen()
+
+    const socket = b.connect(server.publicKey, {
+      fastOpen: false,
+      localConnection: false,
+      // Fires once the client has decoded the server's round-1 reply, right
+      // before it would try to punch. Confirms *why* it is about to fail,
+      // independent of whatever error code ends up on the socket.
+      holepunch(remoteFirewall, _, remoteAddresses) {
+        lc.is(remoteFirewall, DHT.FIREWALL.OPEN, 'server reported itself as OPEN')
+        lc.alike(remoteAddresses, [], 'but gave no addresses to actually punch to')
+        return true // let it proceed into the real punch(), which is what actually fails
+      }
+    })
+
+    socket.once('open', function () {
+      lc.pass('client connected')
+    })
+
+    socket.once('error', function (err) {
+      lc.fail('client connection failed: ' + err)
+    })
+
+    await lc
+
+    await server.close()
+    await a.destroy()
+    await b.destroy()
+  }
+)
+
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)
 

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,5 +1,6 @@
 const test = require('brittle')
 const Holepuncher = require('../lib/holepuncher.js')
+const { FIREWALL } = require('../lib/constants')
 
 test('holepuncher match - nothing to match', async function (t) {
   t.is(Holepuncher.matchAddress([], []), null)
@@ -138,6 +139,45 @@ test('holepuncher match - container vs container (on same host)', async function
   t.alike(Holepuncher.matchAddress([{ host: '172.17.0.2' }], [{ host: '172.17.0.3' }]), {
     host: '172.17.0.3'
   })
+})
+
+// TODO Decide if an OPEN NAT should return addresses
+test.solo('punch - remote reports OPEN firewall but no addresses', async function (t) {
+  // A minimal stand-in for the real dht, just enough for the Holepuncher/Nat
+  // constructors to run without touching the network. Same shape used by
+  // test/nat.js.
+  const fakeDht = {
+    firewalled: false,
+    nodes: { length: 0, latest: null },
+    _socketPool: {
+      acquire() {
+        return { socket: {}, release() {} }
+      }
+    }
+  }
+
+  const puncher = new Holepuncher(fakeDht, null, true)
+
+  // This is exactly what updateRemote() receives when the wire payload had
+  // firewall: FIREWALL.OPEN and addresses: null (messages.js decodes a
+  // missing addresses field to null - see holepunchPayload.decode).
+  puncher.updateRemote({
+    punching: true,
+    firewall: FIREWALL.OPEN,
+    addresses: null,
+    verified: null
+  })
+
+  t.is(puncher.remoteFirewall, FIREWALL.OPEN)
+  t.alike(puncher.remoteAddresses, [])
+
+  // _punch() bails on the empty address list before it ever looks at
+  // remoteFirewall, so an OPEN-but-addressless remote is treated the same
+  // as REMOTE_NOT_HOLEPUNCHABLE by the caller (see connect.js roundPunch).
+  t.absent(await puncher.punch())
+  t.is(puncher.punching, false)
+
+  puncher.destroy()
 })
 
 test.skip('holepuncher match - container on host vs container on virtual machine', async function (t) {})


### PR DESCRIPTION
Tests exploring edgecase where peers can't connect because remote peer flips to OPEN (because of slow NAT sampling) and causes holepunch to be aborted.