### PR TITLE
test: verify mixed-version fast-open guards

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -223,6 +223,7 @@ async function holepunch(c, opts) {
 
   const remoteHolepunchable = !!(payload.holepunch && payload.holepunch.relays.length)
   const relayed = diffAddress(serverAddress, relayAddress)
+  let fastOpen = opts.fastOpen !== false
 
   if (payload.firewall === FIREWALL.OPEN || (relayed && !remoteHolepunchable)) {
     const addr = getFirstRemoteAddress(payload.addresses4, serverAddress)
@@ -254,6 +255,9 @@ async function holepunch(c, opts) {
     if (serverAddresses.length > 0) {
       const myAddresses = Holepuncher.localAddresses(c.dht.io.serverSocket)
       const addr = Holepuncher.matchAddress(myAddresses, serverAddresses) || serverAddresses[0]
+
+      // Do not let the initial probe claim the route before the LAN attempt settles.
+      fastOpen = false
 
       const socket = c.dht.io.serverSocket
       c.dht.ping(addr).then(onlanconnect, onlanerror)
@@ -290,7 +294,7 @@ async function holepunch(c, opts) {
 
   let probe
   try {
-    probe = await probeRound(c, opts.fastOpen === false ? null : serverAddress, serverRelay, true)
+    probe = await probeRound(c, fastOpen ? serverAddress : null, serverRelay, true)
   } catch (err) {
     destroyPuncher(c)
     // TODO: we should retry here with some of the other relays, bail for now

--- a/lib/holepuncher.js
+++ b/lib/holepuncher.js
@@ -123,6 +123,9 @@ module.exports = class Holepuncher {
 
   _onholepunchmessage(_, addr, ref) {
     if (!this.isInitiator) {
+      // Do not echo early probes before this side has committed to coordinated punching.
+      if (!this.punching) return
+
       // TODO: we don't need this if we had a way to connect a socket to many hosts
       holepunch(ref.socket, addr, false) // never fails
       return

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "bare-node-child-process": "^1.0.1",
     "brittle": "^3.0.0",
     "graceful-goodbye": "^1.3.0",
+    "hyperdht-6-33-1": "npm:hyperdht@6.33.1",
     "newline-decoder": "^1.0.2",
     "prettier": "^3.6.2",
     "prettier-config-holepunch": "^2.0.0"

--- a/test/connections.js
+++ b/test/connections.js
@@ -3,6 +3,7 @@ const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
 const DHT = require('../')
+const Holepuncher = require('../lib/holepuncher')
 
 test('createServer + connect - once defaults', async function (t) {
   t.plan(2)
@@ -296,6 +297,128 @@ test('createServer + connect - same-LAN explicit keypair opens server', async fu
   await a.destroy()
   await b.destroy()
 })
+
+test('createServer + connect - unmatched LAN address skips initial fast-open probe', async function (t) {
+  await runLanFastOpenCase(t, false)
+})
+
+test('createServer + connect - matched LAN address skips initial fast-open probe', async function (t) {
+  await runLanFastOpenCase(t, true)
+})
+
+test('createServer + connect - non-LAN connection preserves intentional server fast-open', async function (t) {
+  const { bootstrap } = await swarm(t, 5)
+  const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  let coordinatedHolepunch = false
+
+  t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+    force: true,
+    order: 1
+  })
+
+  const server = serverDHT.createServer({ shareLocalAddress: false }, function (socket) {
+    socket.on('data', function (data) {
+      socket.end(data)
+    })
+  })
+
+  await server.listen()
+
+  const socket = clientDHT.connect(server.publicKey, {
+    localConnection: false,
+    holepunch() {
+      coordinatedHolepunch = true
+      return true
+    }
+  })
+  socket.end('ping')
+
+  const [data] = await once(socket, 'data')
+  t.alike(data, Buffer.from('ping'))
+  t.is(coordinatedHolepunch, false, 'connected before coordinated holepunching')
+})
+
+async function runLanFastOpenCase(t, matched) {
+  const { bootstrap } = await swarm(t, 3)
+  const serverDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientDHT = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  t.teardown(() => Promise.all([serverDHT.destroy(), clientDHT.destroy()]), {
+    force: true,
+    order: 1
+  })
+
+  await serverDHT.fullyBootstrapped()
+  await clientDHT.fullyBootstrapped()
+
+  const server = serverDHT.createServer()
+
+  await server.listen(DHT.keyPair())
+
+  const matchAddress = Holepuncher.matchAddress
+  const openSession = Holepuncher.prototype.openSession
+  const peerHolepunch = clientDHT._router.peerHolepunch
+  const ping = clientDHT.ping
+  const clientPort = clientDHT.io.serverSocket.address().port
+  const serverPort = serverDHT.io.serverSocket.address().port
+  let triedLan = false
+  let sentInitialProbe = false
+  let onholepunch
+  const holepunching = new Promise((resolve) => {
+    onholepunch = resolve
+  })
+
+  // Make the address classification deterministic for the client while
+  // preserving the real server-side classification.
+  Holepuncher.matchAddress = function (localAddresses, remoteAddresses) {
+    if (localAddresses[0].port === clientPort) {
+      return matched ? remoteAddresses[0] : null
+    }
+    return matchAddress(localAddresses, remoteAddresses)
+  }
+
+  Holepuncher.prototype.openSession = function (addr, socket) {
+    if (this.dht === clientDHT) {
+      sentInitialProbe = true
+      return Promise.resolve()
+    }
+    return openSession.call(this, addr, socket)
+  }
+
+  t.teardown(
+    () => {
+      Holepuncher.matchAddress = matchAddress
+      Holepuncher.prototype.openSession = openSession
+      clientDHT._router.peerHolepunch = peerHolepunch
+      clientDHT.ping = ping
+    },
+    { force: true, order: -1 }
+  )
+
+  clientDHT.ping = function (addr, ...args) {
+    if (addr.port === serverPort) {
+      triedLan = true
+      return Promise.reject(new Error('stop LAN probe'))
+    }
+    return ping.call(this, addr, ...args)
+  }
+
+  clientDHT._router.peerHolepunch = async function () {
+    onholepunch()
+    throw new Error('stop holepunch probe')
+  }
+
+  const socket = clientDHT.connect(server.publicKey)
+  socket.on('error', () => {})
+
+  await holepunching
+
+  t.ok(triedLan, 'client started the LAN attempt')
+  t.is(sentInitialProbe, false, 'client skipped the initial probe')
+
+  socket.destroy()
+}
 
 test('server choosing to abort holepunch', async function (t) {
   const [boot] = await swarm(t)

--- a/test/holepuncher.js
+++ b/test/holepuncher.js
@@ -1,6 +1,30 @@
 const test = require('brittle')
 const Holepuncher = require('../lib/holepuncher.js')
 
+test('holepuncher only echoes after local punching starts', function (t) {
+  let sent = 0
+  const puncher = Object.assign(Object.create(Holepuncher.prototype), {
+    isInitiator: false,
+    remoteHolepunching: true,
+    punching: false
+  })
+  const ref = {
+    socket: {
+      send() {
+        sent++
+      }
+    }
+  }
+  const address = { host: '127.0.0.1', port: 1234 }
+
+  puncher._onholepunchmessage(null, address, ref)
+  t.is(sent, 0, 'peer intent alone does not enable echoes')
+
+  puncher.punching = true
+  puncher._onholepunchmessage(null, address, ref)
+  t.is(sent, 1, 'echoes after local punching starts')
+})
+
 test('holepuncher match - nothing to match', async function (t) {
   t.is(Holepuncher.matchAddress([], []), null)
 

--- a/test/integration/lan-fast-open-compat.js
+++ b/test/integration/lan-fast-open-compat.js
@@ -1,0 +1,320 @@
+const test = require('brittle')
+const HyperDHT = require('../..')
+const HyperDHT6331 = require('hyperdht-6-33-1')
+const Holepuncher = require('../../lib/holepuncher')
+const { swarm } = require('../helpers')
+
+test(
+  'mixed-version fast-open - current initiator falls back to 6.33.1 responder after LAN miss',
+  { timeout: 30000 },
+  async function (t) {
+    const { initiator, responder } = await setupMixedPair(t, HyperDHT, HyperDHT6331)
+    const ping = initiator.ping
+    const openSession = Holepuncher.prototype.openSession
+    const peerHolepunch = initiator._router.peerHolepunch
+    const receivedByServer = defer()
+    const receivedByClient = defer()
+    let lanAttempts = 0
+    let openSessions = 0
+    let probesBeforeFirstControl = null
+    let coordinatedFallback = false
+
+    const server = responder.createServer(function (socket) {
+      socket.on('error', receivedByServer.reject)
+      socket.once('data', function (data) {
+        receivedByServer.resolve(data)
+        socket.write('old-server-to-current')
+      })
+    })
+
+    await server.listen()
+
+    const responderPort = responder.io.serverSocket.address().port
+
+    // Make the advertised LAN route fail so the normal mixed-version
+    // holepunch path has to complete the connection.
+    initiator.ping = function (addr, ...args) {
+      if (addr.port === responderPort) {
+        lanAttempts++
+        return Promise.reject(new Error('forced LAN miss'))
+      }
+      return ping.call(this, addr, ...args)
+    }
+
+    Holepuncher.prototype.openSession = function (...args) {
+      if (this.dht === initiator) openSessions++
+      return openSession.apply(this, args)
+    }
+
+    initiator._router.peerHolepunch = function (...args) {
+      if (probesBeforeFirstControl === null) probesBeforeFirstControl = openSessions
+      return peerHolepunch.apply(this, args)
+    }
+
+    t.teardown(
+      () => {
+        initiator.ping = ping
+        Holepuncher.prototype.openSession = openSession
+        initiator._router.peerHolepunch = peerHolepunch
+      },
+      { force: true, order: -1 }
+    )
+
+    const socket = initiator.connect(server.publicKey, {
+      holepunch() {
+        coordinatedFallback = true
+        return true
+      }
+    })
+
+    t.teardown(() => socket.destroy(), { force: true })
+
+    socket.on('error', receivedByClient.reject)
+    socket.once('data', receivedByClient.resolve)
+    socket.write('current-to-old-server')
+
+    const [serverData, clientData] = await Promise.all([
+      receivedByServer.promise,
+      receivedByClient.promise
+    ])
+
+    t.ok(lanAttempts > 0, 'initiator tried the advertised LAN route')
+    t.is(probesBeforeFirstControl, 0, 'initiator skipped the speculative probe')
+    t.ok(coordinatedFallback, 'initiator fell back to coordinated holepunching')
+    t.alike(serverData, Buffer.from('current-to-old-server'), 'old responder received client data')
+    t.alike(clientData, Buffer.from('old-server-to-current'), 'current initiator received reply')
+  }
+)
+
+test(
+  'mixed-version fast-open - reordered 6.33.1 probe connects after responder accepts',
+  { timeout: 30000 },
+  async function (t) {
+    const { initiator, responder } = await setupMixedPair(t, HyperDHT6331, HyperDHT)
+    const reorderedProbe = reorderInitialProbe(t, initiator, responder)
+    const receivedByServer = defer()
+    const receivedByClient = defer()
+
+    const server = responder.createServer(
+      {
+        shareLocalAddress: false,
+        holepunch() {
+          return true
+        }
+      },
+      function (socket) {
+        socket.on('error', receivedByServer.reject)
+        socket.once('data', function (data) {
+          receivedByServer.resolve(data)
+          socket.write('current-server-to-old')
+        })
+      }
+    )
+
+    await server.listen()
+
+    const socket = initiator.connect(server.publicKey, { localConnection: false })
+
+    t.teardown(() => socket.destroy(), { force: true })
+
+    socket.on('error', receivedByClient.reject)
+    socket.once('data', receivedByClient.resolve)
+    socket.write('old-to-current-server')
+
+    const [window, serverData, clientData] = await Promise.all([
+      reorderedProbe,
+      receivedByServer.promise,
+      receivedByClient.promise
+    ])
+
+    t.alike(
+      window,
+      { remote: true, local: false, echoed: false },
+      'delayed probe was ignored before local punching started'
+    )
+    t.alike(serverData, Buffer.from('old-to-current-server'), 'current responder received data')
+    t.alike(clientData, Buffer.from('current-server-to-old'), 'old initiator received reply')
+  }
+)
+
+test(
+  'mixed-version fast-open - reordered 6.33.1 probe cannot bypass responder rejection',
+  { timeout: 30000 },
+  async function (t) {
+    const { initiator, responder } = await setupMixedPair(t, HyperDHT6331, HyperDHT)
+    const reorderedProbe = reorderInitialProbe(t, initiator, responder)
+    const serverRejected = defer()
+    let serverConnected = false
+
+    const server = responder.createServer(
+      {
+        shareLocalAddress: false,
+        holepunch() {
+          serverRejected.resolve()
+          return false
+        }
+      },
+      function (socket) {
+        serverConnected = true
+        socket.on('error', () => {})
+        socket.destroy()
+      }
+    )
+
+    await server.listen()
+
+    const outcome = defer()
+    const socket = initiator.connect(server.publicKey, { localConnection: false })
+
+    t.teardown(() => socket.destroy(), { force: true })
+
+    socket.once('open', () => {
+      outcome.resolve({ event: 'open' })
+    })
+    socket.once('error', (err) => {
+      outcome.resolve({ event: 'error', code: err.code })
+    })
+
+    const [window, , result] = await Promise.all([
+      reorderedProbe,
+      serverRejected.promise,
+      outcome.promise
+    ])
+
+    t.alike(
+      window,
+      { remote: true, local: false, echoed: false },
+      'peer intent alone does not enable responder echoes'
+    )
+    t.alike(
+      result,
+      { event: 'error', code: 'HOLEPUNCH_ABORTED' },
+      'rejected holepunch does not false-open the old client'
+    )
+    t.is(serverConnected, false, 'server did not accept a connection')
+  }
+)
+
+async function setupMixedPair(t, Initiator, Responder) {
+  const { bootstrap } = await swarm(t, 5)
+  const responder = new Responder({
+    bootstrap,
+    host: '127.0.0.1',
+    quickFirewall: false,
+    ephemeral: true
+  })
+  const initiator = new Initiator({
+    bootstrap,
+    host: '127.0.0.1',
+    quickFirewall: false,
+    ephemeral: true
+  })
+
+  t.teardown(() => Promise.allSettled([responder.destroy(), initiator.destroy()]), {
+    force: true,
+    order: 1
+  })
+
+  await Promise.all([responder.fullyBootstrapped(), initiator.fullyBootstrapped()])
+
+  return { initiator, responder }
+}
+
+function reorderInitialProbe(t, initiator, responder) {
+  const onholepunchmessage = Holepuncher.prototype._onholepunchmessage
+  const updateRemote = Holepuncher.prototype.updateRemote
+  const ping = Holepuncher.prototype.ping
+  const peerHolepunch = initiator._router.peerHolepunch
+  const probeHeld = defer()
+  const probeReleased = defer()
+  let held = null
+  let released = false
+
+  Holepuncher.prototype._onholepunchmessage = function (...args) {
+    if (this.dht !== responder || this.isInitiator || this.remoteHolepunching || held !== null) {
+      return onholepunchmessage.apply(this, args)
+    }
+
+    held = { puncher: this, args }
+    probeHeld.resolve()
+  }
+
+  Holepuncher.prototype.updateRemote = function (state) {
+    const result = updateRemote.call(this, state)
+
+    if (
+      this.dht !== responder ||
+      this.isInitiator ||
+      !state.punching ||
+      held === null ||
+      released
+    ) {
+      return result
+    }
+
+    released = true
+
+    const delayed = held
+    const ref = delayed.args[2]
+    const send = ref.socket.send
+    const hadOwnSend = Object.hasOwn(ref.socket, 'send')
+    let echoed = false
+
+    held = null
+    ref.socket.send = function (...args) {
+      echoed = true
+      return send.apply(this, args)
+    }
+
+    try {
+      onholepunchmessage.apply(delayed.puncher, delayed.args)
+    } finally {
+      if (hadOwnSend) ref.socket.send = send
+      else delete ref.socket.send
+
+      probeReleased.resolve({
+        remote: delayed.puncher.remoteHolepunching,
+        local: delayed.puncher.punching,
+        echoed
+      })
+    }
+
+    return result
+  }
+
+  // Isolate the reordered probe from intentional analyzed server fast-open.
+  Holepuncher.prototype.ping = function (...args) {
+    if (this.dht === responder) return Promise.resolve()
+    return ping.apply(this, args)
+  }
+
+  // Ensure the initial UDP probe is held before its control request proceeds.
+  initiator._router.peerHolepunch = async function (...args) {
+    await probeHeld.promise
+    return peerHolepunch.apply(this, args)
+  }
+
+  t.teardown(
+    () => {
+      probeHeld.resolve()
+      probeReleased.resolve(null)
+      Holepuncher.prototype._onholepunchmessage = onholepunchmessage
+      Holepuncher.prototype.updateRemote = updateRemote
+      Holepuncher.prototype.ping = ping
+      initiator._router.peerHolepunch = peerHolepunch
+    },
+    { force: true, order: -1 }
+  )
+
+  return probeReleased.promise
+}
+
+function defer() {
+  let resolve
+  let reject
+  const promise = new Promise((done, fail) => {
+    resolve = done
+    reject = fail
+  })
+  return { promise, resolve, reject }
+}


### PR DESCRIPTION
Test-only draft stacked on #278.

This pins `hyperdht@6.33.1` and provides deterministic evidence for the mixed-version fast-open races:

- updated initiator → 6.33.1 responder: the detected LAN attempt suppresses the unsafe initial probe;
- 6.33.1 initiator → updated responder: a delayed probe arriving after remote intent but before local punching cannot bypass responder rejection.

This draft is evidence only and is not intended to merge. The version pin and implementation-level instrumentation are kept out of #278 to preserve its signal-to-noise ratio.

Co-authored with AI