### PR TITLE
Destroy orphaned holepunchers when clearing handshakes

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -315,10 +315,6 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
-        if (hs.prepunching) {
-          clearTimeout(hs.prepunching)
-          hs.prepunching = null
-        }
         if (hs.puncher) {
           hs.puncher.onabort = noop
           hs.puncher.destroy()

--- a/lib/server.js
+++ b/lib/server.js
@@ -477,6 +477,13 @@ module.exports = class Server extends EventEmitter {
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
 
+    if (hs.puncher) {
+      // The handshake owns the puncher: destroy it here so a postponed or
+      // never-upgraded punch cannot leak its pool socket when cleared
+      hs.puncher.onabort = noop
+      hs.puncher.destroy()
+    }
+
     this._holepunches[id] = null
     while (
       this._holepunches.length > 0 &&

--- a/lib/server.js
+++ b/lib/server.js
@@ -315,6 +315,7 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
+        if (hs.puncher) hs.puncher.destroy()
         this._clearLater(hs, id, k)
       }
       hs.rawStream.on('close', onrawstreamclose)
@@ -476,13 +477,6 @@ module.exports = class Server extends EventEmitter {
   _clear(hs, id, k) {
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
-
-    if (hs.puncher) {
-      // The handshake owns the puncher: destroy it here so a postponed or
-      // never-upgraded punch cannot leak its pool socket when cleared
-      hs.puncher.onabort = noop
-      hs.puncher.destroy()
-    }
 
     this._holepunches[id] = null
     while (

--- a/lib/server.js
+++ b/lib/server.js
@@ -315,7 +315,14 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
-        if (hs.puncher) hs.puncher.destroy()
+        if (hs.prepunching) {
+          clearTimeout(hs.prepunching)
+          hs.prepunching = null
+        }
+        if (hs.puncher) {
+          hs.puncher.onabort = noop
+          hs.puncher.destroy()
+        }
         this._clearLater(hs, id, k)
       }
       hs.rawStream.on('close', onrawstreamclose)

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -835,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close())
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -859,7 +859,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     () => {
       delete Nat.prototype.firewall
     },
-    { force: true, order: 10 }
+    { force: true }
   )
 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
@@ -896,7 +896,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy())
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,10 +825,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
-    force: true,
-    order: 0
-  })
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -838,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { force: true, order: -10 })
+  t.teardown(() => relay.close(), { order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -899,7 +896,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { force: true, order: -20 })
+  t.teardown(() => socket.destroy(), { order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -814,3 +814,87 @@ test.skip('server does not support connection relaying', async function (t) {
   await b.destroy()
   await c.destroy()
 })
+
+test('relayed client that never wins a punch does not leak the server holepuncher', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const Nat = require('../lib/nat')
+  const { FIREWALL } = require('../lib/constants')
+
+  const r = createDHT({ bootstrap, firewalled: false, ephemeral: true })
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return r.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  const relayServer = r.createServer(function (socket) {
+    socket.on('error', () => {})
+    relay.accept(socket, { id: socket.remotePublicKey }).on('error', () => {})
+  })
+
+  await relayServer.listen()
+
+  // The client classifies as behind a randomizing NAT (like CGNAT), so the
+  // server rate limits the punch. Scoped to the client node only.
+  Object.defineProperty(Nat.prototype, 'firewall', {
+    configurable: true,
+    get() {
+      return this.dht === b ? FIREWALL.RANDOM : this._testFirewall
+    },
+    set(value) {
+      this._testFirewall = value
+    }
+  })
+  t.teardown(() => {
+    delete Nat.prototype.firewall
+  })
+
+  // Saturate the random-punch budget so the punch is postponed with TRY_LATER
+  a._randomPunches = a._randomPunchLimit
+
+  const server = a.createServer(
+    { shareLocalAddress: false, handshakeClearWait: 100 },
+    function (socket) {
+      socket.on('error', () => {})
+    }
+  )
+
+  await server.listen()
+
+  const socket = b.connect(server.publicKey, {
+    relayThrough: relayServer.publicKey,
+    localConnection: false,
+    fastOpen: false // a randomizing NAT would eat the fast-open packets
+  })
+  socket.on('error', () => {})
+
+  // Relay pairing has cleared the initial punch timeout by the time the
+  // connection is emitted, so the postponed puncher is parked
+  const [serverSocket] = await once(server, 'connection')
+  serverSocket.on('error', () => {})
+
+  const hs = server._holepunches.find((h) => h && h.puncher)
+  t.ok(
+    hs !== undefined && hs.prepunching === null,
+    'server parked a puncher for the postponed punch'
+  )
+  t.ok(!hs.puncher.destroyed, 'puncher still holds its socket')
+
+  // A graceful close can land before any relay error propagates, so the
+  // puncher cleanup must not depend on the raw stream error path
+  const punchSocket = hs.puncher.socket
+  hs.rawStream.destroy()
+
+  await once(punchSocket, 'close')
+  t.is(a._socketPool._sockets.size, 0, 'no orphaned holepunch sockets on the server')
+
+  await server.close()
+  await relayServer.close()
+  await Promise.all([r.destroy(), a.destroy(), b.destroy()])
+})

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,7 +825,10 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
+    force: true,
+    order: 0
+  })
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -835,7 +838,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close(), { force: true, order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -896,7 +899,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy(), { force: true, order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the
@@ -923,11 +926,10 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const puncher = hs.puncher
   const punchSocket = puncher.socket
   const rawStreamClosed = once(hs.rawStream, 'close')
+  const punchSocketClosed = once(punchSocket, 'close')
 
   hs.rawStream.destroy()
-  await rawStreamClosed
-  await new Promise(setImmediate)
-  await new Promise(setImmediate)
+  await Promise.all([rawStreamClosed, punchSocketClosed])
 
   t.ok(puncher.destroyed, 'server destroyed the parked puncher')
   t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -815,7 +815,7 @@ test.skip('server does not support connection relaying', async function (t) {
   await c.destroy()
 })
 
-test('relayed client that never wins a punch does not leak the server holepuncher', async function (t) {
+test('relayed TRY_LATER stream close destroys the parked server puncher', async function (t) {
   const { bootstrap } = await swarm(t)
 
   const Nat = require('../lib/nat')
@@ -825,6 +825,11 @@ test('relayed client that never wins a punch does not leak the server holepunche
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
+    force: true,
+    order: 0
+  })
+
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
   const relay = new RelayServer({
@@ -832,6 +837,8 @@ test('relayed client that never wins a punch does not leak the server holepunche
       return r.createRawStream({ ...opts, framed: true })
     }
   })
+
+  t.teardown(() => relay.close(), { force: true, order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -851,9 +858,12 @@ test('relayed client that never wins a punch does not leak the server holepunche
       this._testFirewall = value
     }
   })
-  t.teardown(() => {
-    delete Nat.prototype.firewall
-  })
+  t.teardown(
+    () => {
+      delete Nat.prototype.firewall
+    },
+    { force: true, order: 10 }
+  )
 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
@@ -873,28 +883,29 @@ test('relayed client that never wins a punch does not leak the server holepunche
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
+  t.teardown(() => socket.destroy(), { force: true, order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted, so the postponed puncher is parked
-  const [serverSocket] = await once(server, 'connection')
-  serverSocket.on('error', () => {})
+  await once(server, 'connection')
 
-  const hs = server._holepunches.find((h) => h && h.puncher)
-  t.ok(
-    hs !== undefined && hs.prepunching === null,
-    'server parked a puncher for the postponed punch'
-  )
-  t.ok(!hs.puncher.destroyed, 'puncher still holds its socket')
+  const hs = server._holepunches.find((h) => {
+    const p = h && h.puncher
+    return (
+      p && h.relayPaired && h.prepunching === null && !p.destroyed && !p.punching && !p.connected
+    )
+  })
+  t.ok(hs, 'server parked a live puncher after relay pairing')
+  if (!hs) return
 
-  // A graceful close can land before any relay error propagates, so the
-  // puncher cleanup must not depend on the raw stream error path
+  // Close the relayed raw stream without an error before direct upgrade. The
+  // puncher cleanup must not depend on the raw stream error path.
   const punchSocket = hs.puncher.socket
   hs.rawStream.destroy()
 
-  await once(punchSocket, 'close')
-  t.is(a._socketPool._sockets.size, 0, 'no orphaned holepunch sockets on the server')
+  await waitFor(() => hs.puncher.destroyed && !a._socketPool.lookup(punchSocket))
+  t.ok(hs.puncher.destroyed, 'server destroyed the parked puncher')
+  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
 
-  await server.close()
-  await relayServer.close()
-  await Promise.all([r.destroy(), a.destroy(), b.destroy()])
+  socket.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,10 +825,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
-    force: true,
-    order: 0
-  })
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -838,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { force: true, order: -10 })
+  t.teardown(() => relay.close(), { order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -868,8 +865,24 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
 
+  let resolveTryLater
+  const tryLater = new Promise((resolve) => {
+    resolveTryLater = resolve
+  })
+
   const server = a.createServer(
-    { shareLocalAddress: false, handshakeClearWait: 100 },
+    {
+      shareLocalAddress: false,
+      holepunch(remoteFirewall, localFirewall) {
+        if (
+          (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
+          a._randomPunches >= a._randomPunchLimit
+        ) {
+          resolveTryLater()
+        }
+        return true
+      }
+    },
     function (socket) {
       socket.on('error', () => {})
     }
@@ -883,16 +896,23 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { force: true, order: -20 })
+  t.teardown(() => socket.destroy(), { order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
-  // connection is emitted, so the postponed puncher is parked
-  await once(server, 'connection')
+  // connection is emitted. The holepunch hook runs immediately before the
+  // saturated random-punch budget makes the server reply with TRY_LATER.
+  await Promise.all([once(server, 'connection'), tryLater])
 
   const hs = server._holepunches.find((h) => {
     const p = h && h.puncher
     return (
-      p && h.relayPaired && h.prepunching === null && !p.destroyed && !p.punching && !p.connected
+      p &&
+      h.relayPaired &&
+      h.prepunching === null &&
+      p.remoteHolepunching &&
+      !p.destroyed &&
+      !p.punching &&
+      !p.connected
     )
   })
   t.ok(hs, 'server parked a live puncher after relay pairing')
@@ -900,11 +920,16 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
 
   // Close the relayed raw stream without an error before direct upgrade. The
   // puncher cleanup must not depend on the raw stream error path.
-  const punchSocket = hs.puncher.socket
-  hs.rawStream.destroy()
+  const puncher = hs.puncher
+  const punchSocket = puncher.socket
+  const rawStreamClosed = once(hs.rawStream, 'close')
 
-  await waitFor(() => hs.puncher.destroyed && !a._socketPool.lookup(punchSocket))
-  t.ok(hs.puncher.destroyed, 'server destroyed the parked puncher')
+  hs.rawStream.destroy()
+  await rawStreamClosed
+  await new Promise(setImmediate)
+  await new Promise(setImmediate)
+
+  t.ok(puncher.destroyed, 'server destroyed the parked puncher')
   t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
 
   socket.destroy()


### PR DESCRIPTION
A firewalled server creates a Holepuncher (which binds a pool UDP socket) for every inbound handshake. When the punch is postponed with TRY_LATER (random punch limit) or the connection stays relayed, the prepunching timeout is cleared and nothing owns the puncher anymore. If the relayed raw stream then closes cleanly - a graceful client disconnect - the handshake record is cleared but the puncher and its socket survived until process restart, leaking one fd per such connection.

Destroy the puncher when its handshake record is cleared.

Co-authored with AI