### PR TITLE
Fix/clear handshake on relay abort

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -315,10 +315,6 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
-        if (hs.prepunching) {
-          clearTimeout(hs.prepunching)
-          hs.prepunching = null
-        }
         if (hs.puncher) {
           hs.puncher.onabort = noop
           hs.puncher.destroy()

--- a/lib/server.js
+++ b/lib/server.js
@@ -477,6 +477,13 @@ module.exports = class Server extends EventEmitter {
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
 
+    if (hs.puncher) {
+      // The handshake owns the puncher: destroy it here so a postponed or
+      // never-upgraded punch cannot leak its pool socket when cleared
+      hs.puncher.onabort = noop
+      hs.puncher.destroy()
+    }
+
     this._holepunches[id] = null
     while (
       this._holepunches.length > 0 &&

--- a/lib/server.js
+++ b/lib/server.js
@@ -19,6 +19,7 @@ const { ALREADY_LISTENING, NODE_DESTROYED, KEYPAIR_ALREADY_USED } = require('./e
 
 const HANDSHAKE_CLEAR_WAIT = 10000
 const HANDSHAKE_INITIAL_TIMEOUT = 10000
+const RELAY_RECOVERY_WAIT = 30000
 
 module.exports = class Server extends EventEmitter {
   constructor(dht, opts = {}) {
@@ -32,6 +33,7 @@ module.exports = class Server extends EventEmitter {
     this.holepunch = opts.holepunch || (() => true)
     this.relayThrough = opts.relayThrough || null
     this.relayKeepAlive = opts.relayKeepAlive || 5000
+    this.relayRecoveryWait = opts.relayRecoveryWait || RELAY_RECOVERY_WAIT
     this.pool = opts.pool || null
     this.createHandshake = opts.createHandshake || defaultCreateHandshake
     this.createSecretStream = opts.createSecretStream || defaultCreateSecretStream
@@ -141,6 +143,7 @@ module.exports = class Server extends EventEmitter {
       if (h && h.puncher) h.puncher.destroy()
       if (h && h.clearing) clearTimeout(h.clearing)
       if (h && h.prepunching) clearTimeout(h.prepunching)
+      if (h) clearRelayRecovery(h)
       if (h && h.rawStream) h.rawStream.destroy()
     }
 
@@ -239,7 +242,8 @@ module.exports = class Server extends EventEmitter {
       relaySocket: null,
       relayClient: null,
       relayPaired: false,
-      relayFailed: false,
+      relayFailedAt: null,
+      relayRecoveryTimeout: null,
       validUpgrade: true
     }
 
@@ -316,6 +320,7 @@ module.exports = class Server extends EventEmitter {
       // This can happen on a relayed connection which never connects directly
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
+        clearRelayRecovery(hs)
         if (this._closing) return
         if (hs.puncher) {
           hs.puncher.onabort = noop
@@ -328,6 +333,7 @@ module.exports = class Server extends EventEmitter {
       hs.onsocket = (socket, port, host) => {
         if (hs.rawStream === null) return // Already hole punched
 
+        clearRelayRecovery(hs)
         this._clearLater(hs, id, k)
 
         if (hs.prepunching) {
@@ -424,6 +430,7 @@ module.exports = class Server extends EventEmitter {
 
     const onabort = () => {
       hs.aborted = true
+      clearRelayRecovery(hs)
       if (hs.prepunching) clearTimeout(hs.prepunching)
       hs.prepunching = null
       if (hs.puncher) {
@@ -480,6 +487,7 @@ module.exports = class Server extends EventEmitter {
   }
 
   _clear(hs, id, k) {
+    clearRelayRecovery(hs)
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
 
@@ -638,7 +646,7 @@ module.exports = class Server extends EventEmitter {
       }
     } finally {
       h.activeHolepunchRequests--
-      maybeDestroyRelayHandshake(h)
+      maybeDestroyRelayHandshake(h, this.relayRecoveryWait)
     }
   }
 
@@ -667,6 +675,7 @@ module.exports = class Server extends EventEmitter {
 
   _relayConnection(hs, relayThrough, remotePayload, h) {
     this.dht.stats.relaying.attempts++
+    const relayRecoveryWait = this.relayRecoveryWait
 
     let isInitiator
     let publicKey
@@ -727,29 +736,50 @@ module.exports = class Server extends EventEmitter {
     function onabort() {
       if (hs.relaySocket !== relaySocket || hs.relayClient !== relayClient) return
       if (!hs.relayPaired) dht.stats.relaying.aborts++
-      hs.relayFailed = true
+      if (hs.relayFailedAt === null) hs.relayFailedAt = Date.now()
       destroyRelayConnection(hs)
-      maybeDestroyRelayHandshake(hs)
+      maybeDestroyRelayHandshake(hs, relayRecoveryWait)
     }
   }
 }
 
-function maybeDestroyRelayHandshake(hs) {
-  if (!hs.relayFailed || hs.rawStream === null || hs.rawStream.destroyed) return
+function maybeDestroyRelayHandshake(hs, relayRecoveryWait) {
+  if (hs.relayFailedAt === null || hs.rawStream === null || hs.rawStream.destroyed) return
 
   if (hs.aborted) {
     hs.rawStream.destroy()
     return
   }
 
-  // A pending prepunch or active holepunch workflow can still recover by
-  // upgrading the raw stream. Recheck when the active workflow completes.
+  // Holepunching spans multiple requests. Give the next round time to arrive,
+  // but anchor the deadline to relay failure so requests cannot extend it.
+  const remaining = relayRecoveryWait - (Date.now() - hs.relayFailedAt)
+  if (remaining > 0) {
+    if (hs.relayRecoveryTimeout !== null) return
+
+    const rawStream = hs.rawStream
+    hs.relayRecoveryTimeout = setTimeout(() => {
+      hs.relayRecoveryTimeout = null
+      if (hs.rawStream !== rawStream) return
+      maybeDestroyRelayHandshake(hs, relayRecoveryWait)
+    }, remaining)
+    hs.relayRecoveryTimeout.unref()
+    return
+  }
+
+  // An active holepunch workflow owns cleanup after the recovery deadline.
   if (hs.prepunching !== null || hs.activeHolepunchRequests > 0) return
 
   const p = hs.puncher
   if (p && p.punching) return
 
   hs.rawStream.destroy()
+}
+
+function clearRelayRecovery(hs) {
+  if (hs.relayRecoveryTimeout !== null) clearTimeout(hs.relayRecoveryTimeout)
+  hs.relayRecoveryTimeout = null
+  hs.relayFailedAt = null
 }
 
 function isConsistent(fw) {

--- a/lib/server.js
+++ b/lib/server.js
@@ -315,6 +315,7 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
+        if (hs.puncher) hs.puncher.destroy()
         this._clearLater(hs, id, k)
       }
       hs.rawStream.on('close', onrawstreamclose)
@@ -476,13 +477,6 @@ module.exports = class Server extends EventEmitter {
   _clear(hs, id, k) {
     if (id >= this._holepunches.length || this._holepunches[id] !== hs) return
     if (hs.clearing) clearTimeout(hs.clearing)
-
-    if (hs.puncher) {
-      // The handshake owns the puncher: destroy it here so a postponed or
-      // never-upgraded punch cannot leak its pool socket when cleared
-      hs.puncher.onabort = noop
-      hs.puncher.destroy()
-    }
 
     this._holepunches[id] = null
     while (

--- a/lib/server.js
+++ b/lib/server.js
@@ -699,7 +699,6 @@ module.exports = class Server extends EventEmitter {
     hs.relayClient = relayClient
     relaySocket.setKeepAlive(this.relayKeepAlive)
     hs.relayTimeout = setTimeout(onabort, 15000)
-    relaySocket.once('close', onabort)
     relayClient.once('close', onabort)
 
     relayClient
@@ -736,7 +735,7 @@ module.exports = class Server extends EventEmitter {
     function onabort() {
       if (hs.relaySocket !== relaySocket || hs.relayClient !== relayClient) return
       if (!hs.relayPaired) dht.stats.relaying.aborts++
-      if (hs.relayFailedAt === null) hs.relayFailedAt = Date.now()
+      hs.relayFailedAt = Date.now()
       destroyRelayConnection(hs)
       maybeDestroyRelayHandshake(hs, relayRecoveryWait)
     }
@@ -757,10 +756,8 @@ function maybeDestroyRelayHandshake(hs, relayRecoveryWait) {
   if (remaining > 0) {
     if (hs.relayRecoveryTimeout !== null) return
 
-    const rawStream = hs.rawStream
     hs.relayRecoveryTimeout = setTimeout(() => {
       hs.relayRecoveryTimeout = null
-      if (hs.rawStream !== rawStream) return
       maybeDestroyRelayHandshake(hs, relayRecoveryWait)
     }, remaining)
     hs.relayRecoveryTimeout.unref()

--- a/lib/server.js
+++ b/lib/server.js
@@ -315,7 +315,14 @@ module.exports = class Server extends EventEmitter {
       // (onsocket is called there only when the direct connection is established)
       const onrawstreamclose = () => {
         if (this._closing) return
-        if (hs.puncher) hs.puncher.destroy()
+        if (hs.prepunching) {
+          clearTimeout(hs.prepunching)
+          hs.prepunching = null
+        }
+        if (hs.puncher) {
+          hs.puncher.onabort = noop
+          hs.puncher.destroy()
+        }
         this._clearLater(hs, id, k)
       }
       hs.rawStream.on('close', onrawstreamclose)

--- a/lib/server.js
+++ b/lib/server.js
@@ -673,13 +673,18 @@ module.exports = class Server extends EventEmitter {
       token = remotePayload.relayThrough.token
     }
 
-    hs.relayToken = token
-    hs.relaySocket = this.dht.connect(publicKey)
-    hs.relaySocket.setKeepAlive(this.relayKeepAlive)
-    hs.relayClient = relay.Client.from(hs.relaySocket, { id: hs.relaySocket.publicKey })
-    hs.relayTimeout = setTimeout(onabort, 15000)
+    const relaySocket = this.dht.connect(publicKey)
+    const relayClient = relay.Client.from(relaySocket, { id: relaySocket.publicKey })
 
-    hs.relayClient
+    hs.relayToken = token
+    hs.relaySocket = relaySocket
+    hs.relayClient = relayClient
+    relaySocket.setKeepAlive(this.relayKeepAlive)
+    hs.relayTimeout = setTimeout(onabort, 15000)
+    relaySocket.once('close', onabort)
+    relayClient.once('close', onabort)
+
+    relayClient
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
@@ -711,9 +716,24 @@ module.exports = class Server extends EventEmitter {
 
     const dht = this.dht
     function onabort() {
+      if (hs.relaySocket !== relaySocket || hs.relayClient !== relayClient) return
       if (!hs.relayPaired) dht.stats.relaying.aborts++
       destroyRelayConnection(hs)
-      if (hs.aborted && hs.rawStream) hs.rawStream.destroy()
+      if (hs.rawStream === null) return
+
+      if (hs.aborted) {
+        hs.rawStream.destroy()
+        return
+      }
+
+      // A pending prepunch or an active puncher can still recover by upgrading
+      // the raw stream. Otherwise relay loss leaves nothing that can close it.
+      if (hs.prepunching !== null) return
+
+      const p = hs.puncher
+      if (p && (p.punching || p.connected)) return
+
+      hs.rawStream.destroy()
     }
   }
 }

--- a/lib/server.js
+++ b/lib/server.js
@@ -231,6 +231,7 @@ module.exports = class Server extends EventEmitter {
       replyFromPuncher: false,
       onsocket: null,
       aborted: false,
+      activeHolepunchRequests: 0,
 
       // Relay state
       relayTimeout: null,
@@ -238,6 +239,7 @@ module.exports = class Server extends EventEmitter {
       relaySocket: null,
       relayClient: null,
       relayPaired: false,
+      relayFailed: false,
       validUpgrade: true
     }
 
@@ -549,87 +551,94 @@ module.exports = class Server extends EventEmitter {
       p.updateRemote({ punching, firewall, addresses, verified: echoed ? peerAddress.host : null })
     }
 
-    // Wait for the analyzer to reach a conclusion...
-    let stable = await p.analyze(false)
-    if (p.destroyed) return null
+    h.activeHolepunchRequests++
 
-    if (!p.remoteHolepunching && !stable) {
-      stable = await p.analyze(true)
+    try {
+      // Wait for the analyzer to reach a conclusion...
+      let stable = await p.analyze(false)
       if (p.destroyed) return null
-      if (!stable) return this._abort(h)
-    }
 
-    // Fast mode! If we are consistent and the remote has opened a session to us (remoteAddress)
-    // then fire a quick punch back. Note the await here just waits for the udp socket to flush.
-    if (
-      isConsistent(p.nat.firewall) &&
-      remoteAddress &&
-      hasSameAddr(p.nat.addresses, remoteAddress)
-    ) {
-      await p.ping(peerAddress)
-      if (p.destroyed) return null
-    }
-
-    // Remote said they are punching (or willing to), so we will punch as well.
-    // Note that this returns when the punching has STARTED, so no guarantee
-    // we will have a connection after this promise etc.
-    if (p.remoteHolepunching) {
-      // TODO: still continue here if a local connection might work, but then do not holepunch...
-      if (!this.holepunch(p.remoteFirewall, p.nat.firewall, p.remoteAddresses, p.nat.addresses)) {
-        return p.destroyed ? null : this._abort(h)
+      if (!p.remoteHolepunching && !stable) {
+        stable = await p.analyze(true)
+        if (p.destroyed) return null
+        if (!stable) return this._abort(h)
       }
 
-      if (h.prepunching) {
-        clearTimeout(h.prepunching)
-        h.prepunching = null
+      // Fast mode! If we are consistent and the remote has opened a session to us (remoteAddress)
+      // then fire a quick punch back. Note the await here just waits for the udp socket to flush.
+      if (
+        isConsistent(p.nat.firewall) &&
+        remoteAddress &&
+        hasSameAddr(p.nat.addresses, remoteAddress)
+      ) {
+        await p.ping(peerAddress)
+        if (p.destroyed) return null
       }
 
-      if (p.remoteFirewall >= FIREWALL.RANDOM || p.nat.firewall >= FIREWALL.RANDOM) {
-        if (
-          this.dht._randomPunches >= this.dht._randomPunchLimit ||
-          Date.now() - this.dht._lastRandomPunch < this.dht._randomPunchInterval
-        ) {
-          if (!h.relayToken) return this._abort(h, ERROR.TRY_LATER)
-          return {
-            socket: p.socket,
-            payload: h.payload.encrypt({
-              error: ERROR.TRY_LATER,
-              firewall: p.nat.firewall,
-              round: h.round,
-              connected: p.connected,
-              punching: p.punching,
-              addresses: p.nat.addresses,
-              remoteAddress: null,
-              token: isServerRelay ? token : null,
-              remoteToken: remotePayload.token
-            })
+      // Remote said they are punching (or willing to), so we will punch as well.
+      // Note that this returns when the punching has STARTED, so no guarantee
+      // we will have a connection after this promise etc.
+      if (p.remoteHolepunching) {
+        // TODO: still continue here if a local connection might work, but then do not holepunch...
+        if (!this.holepunch(p.remoteFirewall, p.nat.firewall, p.remoteAddresses, p.nat.addresses)) {
+          return p.destroyed ? null : this._abort(h)
+        }
+
+        if (h.prepunching) {
+          clearTimeout(h.prepunching)
+          h.prepunching = null
+        }
+
+        if (p.remoteFirewall >= FIREWALL.RANDOM || p.nat.firewall >= FIREWALL.RANDOM) {
+          if (
+            this.dht._randomPunches >= this.dht._randomPunchLimit ||
+            Date.now() - this.dht._lastRandomPunch < this.dht._randomPunchInterval
+          ) {
+            if (!h.relayToken) return this._abort(h, ERROR.TRY_LATER)
+            return {
+              socket: p.socket,
+              payload: h.payload.encrypt({
+                error: ERROR.TRY_LATER,
+                firewall: p.nat.firewall,
+                round: h.round,
+                connected: p.connected,
+                punching: p.punching,
+                addresses: p.nat.addresses,
+                remoteAddress: null,
+                token: isServerRelay ? token : null,
+                remoteToken: remotePayload.token
+              })
+            }
           }
         }
+
+        const punching = await p.punch()
+        if (p.destroyed) return null
+        if (!punching) return this._abort(h)
       }
 
-      const punching = await p.punch()
-      if (p.destroyed) return null
-      if (!punching) return this._abort(h)
-    }
+      // Freeze that analysis as soon as we have a result we are giving to the other peer
+      if (p.nat.firewall !== FIREWALL.UNKNOWN) {
+        p.nat.freeze()
+      }
 
-    // Freeze that analysis as soon as we have a result we are giving to the other peer
-    if (p.nat.firewall !== FIREWALL.UNKNOWN) {
-      p.nat.freeze()
-    }
-
-    return {
-      socket: p.socket,
-      payload: h.payload.encrypt({
-        error: ERROR.NONE,
-        firewall: p.nat.firewall,
-        round: h.round,
-        connected: p.connected,
-        punching: p.punching,
-        addresses: p.nat.addresses,
-        remoteAddress: null,
-        token: isServerRelay ? token : null,
-        remoteToken: remotePayload.token
-      })
+      return {
+        socket: p.socket,
+        payload: h.payload.encrypt({
+          error: ERROR.NONE,
+          firewall: p.nat.firewall,
+          round: h.round,
+          connected: p.connected,
+          punching: p.punching,
+          addresses: p.nat.addresses,
+          remoteAddress: null,
+          token: isServerRelay ? token : null,
+          remoteToken: remotePayload.token
+        })
+      }
+    } finally {
+      h.activeHolepunchRequests--
+      maybeDestroyRelayHandshake(h)
     }
   }
 
@@ -718,24 +727,29 @@ module.exports = class Server extends EventEmitter {
     function onabort() {
       if (hs.relaySocket !== relaySocket || hs.relayClient !== relayClient) return
       if (!hs.relayPaired) dht.stats.relaying.aborts++
+      hs.relayFailed = true
       destroyRelayConnection(hs)
-      if (hs.rawStream === null) return
-
-      if (hs.aborted) {
-        hs.rawStream.destroy()
-        return
-      }
-
-      // A pending prepunch or an active puncher can still recover by upgrading
-      // the raw stream. Otherwise relay loss leaves nothing that can close it.
-      if (hs.prepunching !== null) return
-
-      const p = hs.puncher
-      if (p && (p.punching || p.connected)) return
-
-      hs.rawStream.destroy()
+      maybeDestroyRelayHandshake(hs)
     }
   }
+}
+
+function maybeDestroyRelayHandshake(hs) {
+  if (!hs.relayFailed || hs.rawStream === null || hs.rawStream.destroyed) return
+
+  if (hs.aborted) {
+    hs.rawStream.destroy()
+    return
+  }
+
+  // A pending prepunch or active holepunch workflow can still recover by
+  // upgrading the raw stream. Recheck when the active workflow completes.
+  if (hs.prepunching !== null || hs.activeHolepunchRequests > 0) return
+
+  const p = hs.puncher
+  if (p && p.punching) return
+
+  hs.rawStream.destroy()
 }
 
 function isConsistent(fw) {

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -567,9 +567,17 @@ test('relay connection upgrades to direct connection', async function (t) {
     { name: 'without keepalive', connectionKeepAlive: false, confirmWithAppData: true },
     { name: 'idle without keepalive', connectionKeepAlive: false },
     {
-      name: 'server relay loss while analyzing',
+      name: 'server relay loss during non-punching probe',
       connectionKeepAlive: false,
       relayFailure: true
+    },
+    {
+      name: 'server relay loss past deadline during a punching request',
+      connectionKeepAlive: false,
+      relayFailure: true,
+      remoteHolepunching: true,
+      relayRecoveryWait: 100,
+      waitForRecoveryExpiry: true
     }
   ]) {
     t.comment(opts.name)
@@ -591,7 +599,10 @@ test('relay connection upgrades to direct connection', async function (t) {
     t.teardown(() => Promise.all([relayNode.destroy(), serverNode.destroy(), clientNode.destroy()]))
 
     const resumePunching = pausePunching(t, [serverNode, clientNode])
-    const pausedAnalysis = opts.relayFailure ? pauseAnalysis(t, serverNode, true) : null
+    const pausedAnalysis = opts.relayFailure
+      ? pauseAnalysis(t, serverNode, !!opts.remoteHolepunching, true)
+      : null
+    let relayFailureHandshake = null
 
     const relayServer = new RelayServer({
       createStream(opts) {
@@ -627,7 +638,8 @@ test('relay connection upgrades to direct connection', async function (t) {
     const appServer = serverNode.createServer(
       {
         relayThrough: relayTransportServer.publicKey,
-        shareLocalAddress: false
+        shareLocalAddress: false,
+        relayRecoveryWait: opts.relayRecoveryWait
       },
       function (socket) {
         resolveServerSocket(socket)
@@ -679,12 +691,17 @@ test('relay connection upgrades to direct connection', async function (t) {
       const hs = appServer._holepunches.find((h) => h && h.relayPaired && h.puncher === puncher)
 
       if (!hs) throw new Error('Missing paired server handshake')
+      relayFailureHandshake = hs
 
       const relaySocket = hs.relaySocket
       const relaySocketClosed = closed(relaySocket)
 
       relaySocket.destroy()
       await withTimeout(relaySocketClosed, 'Timed out waiting for the server relay socket to close')
+
+      if (opts.waitForRecoveryExpiry) {
+        await new Promise((resolve) => setTimeout(resolve, appServer.relayRecoveryWait * 1.2))
+      }
 
       t.ok(!hs.rawStream.destroyed, 'server keeps the recoverable raw stream alive')
 
@@ -712,6 +729,14 @@ test('relay connection upgrades to direct connection', async function (t) {
       await withTimeout(upgraded, 'Timed out waiting for direct upgrade after relay loss')
     } else {
       await upgraded
+    }
+
+    if (relayFailureHandshake) {
+      t.is(
+        relayFailureHandshake.relayRecoveryTimeout,
+        null,
+        'server clears the recovery timer after direct upgrade'
+      )
     }
 
     const relaysClosed = Promise.all(relaySocketsClosed)
@@ -912,7 +937,7 @@ test.skip('server does not support connection relaying', async function (t) {
   await c.destroy()
 })
 
-test('paired relay loss clears parked and in-flight idle handshakes', async function (t) {
+test('paired relay loss eventually clears a parked TRY_LATER handshake', async function (t) {
   const { bootstrap } = await swarm(t)
 
   const Nat = require('../lib/nat')
@@ -962,17 +987,22 @@ test('paired relay loss clears parked and in-flight idle handshakes', async func
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
 
-  let resolveTryLater = null
+  let resolveTryLater
+  const tryLater = new Promise((resolve) => {
+    resolveTryLater = resolve
+  })
 
   const server = a.createServer(
     {
       shareLocalAddress: false,
+      handshakeClearWait: 100,
+      relayRecoveryWait: 200,
       holepunch(remoteFirewall, localFirewall) {
         if (
           (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
           a._randomPunches >= a._randomPunchLimit
         ) {
-          if (resolveTryLater) resolveTryLater()
+          resolveTryLater()
         }
         return true
       }
@@ -984,87 +1014,61 @@ test('paired relay loss clears parked and in-flight idle handshakes', async func
 
   await server.listen()
 
-  for (const relayFailure of ['after TRY_LATER', 'during a non-punching probe']) {
-    t.comment(relayFailure)
+  const connection = once(server, 'connection')
+  const socket = b.connect(server.publicKey, {
+    relayThrough: relayServer.publicKey,
+    localConnection: false,
+    fastOpen: false // a randomizing NAT would eat the fast-open packets
+  })
+  socket.on('error', () => {})
+  const socketClosed = closed(socket)
+  t.teardown(() => socket.destroy())
 
-    const probing = relayFailure.startsWith('during')
-    const tryLater = probing
-      ? null
-      : new Promise((resolve) => {
-          resolveTryLater = resolve
-        })
-    const resumePunching = probing ? pausePunching(t, [a, b]) : null
-    // Keep this request on the normal idle-return path so cleanup must come
-    // from the request's finally block rather than _abort().
-    const pausedAnalysis = probing ? pauseAnalysis(t, a, false, true) : null
+  await withTimeout(
+    Promise.all([connection, tryLater]),
+    'Timed out waiting for the relayed connection and TRY_LATER decision'
+  )
 
-    const connection = once(server, 'connection')
-    const socket = b.connect(server.publicKey, {
-      relayThrough: relayServer.publicKey,
-      localConnection: false,
-      fastOpen: false // a randomizing NAT would eat the fast-open packets
-    })
-    socket.on('error', () => {})
-    const socketClosed = closed(socket)
-    t.teardown(() => socket.destroy())
-
-    let activePuncher = null
-    if (pausedAnalysis) {
-      const [, puncher] = await withTimeout(
-        Promise.all([connection, pausedAnalysis.active]),
-        'Timed out waiting for the relayed connection and server NAT analysis'
-      )
-      activePuncher = puncher
-      const updateRemote = puncher.updateRemote
-      puncher.updateRemote = function (state) {
-        return updateRemote.call(this, { ...state, punching: false })
-      }
-    } else {
-      // Relay pairing has cleared the initial punch timeout by the time the
-      // connection is emitted. The hook runs immediately before TRY_LATER.
-      await withTimeout(
-        Promise.all([connection, tryLater]),
-        'Timed out waiting for the relayed connection and TRY_LATER decision'
-      )
-    }
-
-    const hs = server._holepunches.find((h) => {
-      const p = h && h.puncher
-      if (!p || !h.relayPaired || p.destroyed || p.punching || p.connected) return false
-      if (activePuncher) return p === activePuncher
-      return h.prepunching === null && p.remoteHolepunching
-    })
-    if (!hs) throw new Error(`Missing ${activePuncher ? 'in-flight' : 'parked'} handshake`)
-
-    const relaySocketClosed = closed(hs.relaySocket)
-    const rawStream = hs.rawStream
-    const punchSocket = hs.puncher.socket
-    const rawStreamClosed = closed(rawStream)
-    const punchSocketClosed = closed(punchSocket)
-
-    hs.relaySocket.destroy()
-    await withTimeout(relaySocketClosed, 'Timed out waiting for the relay socket to close')
-
-    if (pausedAnalysis) {
-      t.ok(!rawStream.destroyed, 'server defers cleanup during active holepunch processing')
-      pausedAnalysis.resume()
-    }
-
-    await withTimeout(
-      Promise.all([rawStreamClosed, punchSocketClosed]),
-      'Timed out waiting for the raw stream and punch socket to close'
+  const hs = server._holepunches.find((h) => {
+    const p = h && h.puncher
+    return (
+      p &&
+      h.relayPaired &&
+      h.prepunching === null &&
+      p.remoteHolepunching &&
+      !p.destroyed &&
+      !p.punching &&
+      !p.connected
     )
+  })
+  if (!hs) throw new Error('Missing parked handshake')
 
-    t.absent(
-      a._socketPool.lookup(punchSocket),
-      `server released the ${probing ? 'in-flight' : 'parked'} punch socket`
-    )
+  const relaySocketClosed = closed(hs.relaySocket)
+  const rawStream = hs.rawStream
+  const punchSocket = hs.puncher.socket
+  const rawStreamClosed = closed(rawStream)
+  const punchSocketClosed = closed(punchSocket)
 
-    if (resumePunching) resumePunching()
-    resolveTryLater = null
-    socket.destroy()
-    await withTimeout(socketClosed, 'Timed out waiting for the client socket to close')
-  }
+  hs.relaySocket.destroy()
+  await withTimeout(relaySocketClosed, 'Timed out waiting for the relay socket to close')
+
+  t.ok(!rawStream.destroyed, 'server keeps the parked handshake during the recovery grace')
+
+  await withTimeout(
+    Promise.all([rawStreamClosed, punchSocketClosed]),
+    'Timed out waiting for relay recovery cleanup'
+  )
+
+  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
+
+  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+  t.absent(
+    server._holepunches.find((h) => h === hs),
+    'server cleared the parked handshake'
+  )
+
+  socket.destroy()
+  await withTimeout(socketClosed, 'Timed out waiting for the client socket to close')
 })
 
 test('relay transport failure while pairing clears a parked handshake', async function (t) {
@@ -1128,6 +1132,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
     {
       shareLocalAddress: false,
       handshakeClearWait: 100,
+      relayRecoveryWait: 100,
       holepunch(remoteFirewall, localFirewall) {
         if (
           (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
@@ -1155,7 +1160,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
 
   // The hook runs immediately before the saturated random-punch budget makes
   // the server reply with TRY_LATER while relay pairing is still pending.
-  await tryLater
+  await withTimeout(tryLater, 'Timed out waiting for the TRY_LATER decision')
 
   const hs = server._holepunches.find((h) => {
     if (!h || !h.puncher) return false
@@ -1240,7 +1245,8 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
       relayThrough: relayServer.publicKey,
       shareLocalAddress: false,
       holepunch: false,
-      handshakeClearWait: 100
+      handshakeClearWait: 100,
+      relayRecoveryWait: 100
     },
     function (socket) {
       socket.on('error', () => {})
@@ -1257,7 +1263,7 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
   socket.on('error', () => {})
   t.teardown(() => socket.destroy())
 
-  await connection
+  await withTimeout(connection, 'Timed out waiting for the relayed connection')
 
   const hs = server._holepunches.find(
     (h) =>

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -233,6 +233,21 @@ function closed(stream) {
   return new Promise((resolve) => stream.once('close', resolve))
 }
 
+function handshakeCleared(server, hs) {
+  const clear = server._clear
+
+  return new Promise((resolve) => {
+    server._clear = function (...args) {
+      const result = clear.apply(this, args)
+      if (args[0] === hs) {
+        server._clear = clear
+        resolve()
+      }
+      return result
+    }
+  })
+}
+
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -600,7 +615,7 @@ test('relay connection upgrades to direct connection', async function (t) {
 
     const resumePunching = pausePunching(t, [serverNode, clientNode])
     const pausedAnalysis = opts.relayFailure
-      ? pauseAnalysis(t, serverNode, !!opts.remoteHolepunching, true)
+      ? pauseAnalysis(t, serverNode, !!opts.remoteHolepunching)
       : null
     let relayFailureHandshake = null
 
@@ -703,8 +718,6 @@ test('relay connection upgrades to direct connection', async function (t) {
         await new Promise((resolve) => setTimeout(resolve, appServer.relayRecoveryWait * 1.2))
       }
 
-      t.ok(!hs.rawStream.destroyed, 'server keeps the recoverable raw stream alive')
-
       pausedAnalysis.resume()
     }
 
@@ -731,7 +744,7 @@ test('relay connection upgrades to direct connection', async function (t) {
       await upgraded
     }
 
-    if (relayFailureHandshake) {
+    if (relayFailureHandshake && !opts.waitForRecoveryExpiry) {
       t.is(
         relayFailureHandshake.relayRecoveryTimeout,
         null,
@@ -745,8 +758,6 @@ test('relay connection upgrades to direct connection', async function (t) {
     } else {
       await relaysClosed
     }
-    t.pass('relay transport sockets close after direct upgrade')
-
     t.is(
       serverSocket.rawStream.remotePort,
       clientSocket.rawStream.localPort,
@@ -848,25 +859,30 @@ test.skip('relay several connections through node with pool', async function (t)
 
 function pausePunching(t, pausedNodes) {
   const punch = Holepuncher.prototype._punch
-  let resume = null
+  let unpause = null
   const punchingResumed = new Promise((resolve) => {
-    resume = resolve
+    unpause = resolve
   })
+
+  let restored = false
+  const resume = () => {
+    if (restored) return
+    restored = true
+    unpause()
+    Holepuncher.prototype._punch = punch
+  }
 
   Holepuncher.prototype._punch = async function () {
     if (pausedNodes.includes(this.dht)) await punchingResumed
     return punch.call(this)
   }
 
-  t.teardown(() => {
-    resume()
-    Holepuncher.prototype._punch = punch
-  })
+  t.teardown(resume, { force: true })
 
   return resume
 }
 
-function pauseAnalysis(t, node, remoteHolepunching, stableResult) {
+function pauseAnalysis(t, node, remoteHolepunching) {
   const analyze = Holepuncher.prototype.analyze
 
   let resolveActive
@@ -888,7 +904,7 @@ function pauseAnalysis(t, node, remoteHolepunching, stableResult) {
     if (this.dht === node && this.remoteHolepunching === remoteHolepunching) {
       resolveActive(this)
       await resumed
-      if (stableResult !== undefined) return stableResult
+      return true // Keep NAT classification out of this lifecycle race.
     }
 
     return analyze.call(this, ...args)
@@ -1048,6 +1064,7 @@ test('paired relay loss eventually clears a parked TRY_LATER handshake', async f
   const punchSocket = hs.puncher.socket
   const rawStreamClosed = closed(rawStream)
   const punchSocketClosed = closed(punchSocket)
+  const cleared = handshakeCleared(server, hs)
 
   hs.relaySocket.destroy()
   await withTimeout(relaySocketClosed, 'Timed out waiting for the relay socket to close')
@@ -1059,9 +1076,7 @@ test('paired relay loss eventually clears a parked TRY_LATER handshake', async f
     'Timed out waiting for relay recovery cleanup'
   )
 
-  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
-
-  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+  await withTimeout(cleared, 'Timed out waiting for the parked handshake to clear')
   t.absent(
     server._holepunches.find((h) => h === hs),
     'server cleared the parked handshake'
@@ -1193,6 +1208,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
   const relayClientClosed = closed(relayClient)
   const rawStreamClosed = closed(rawStream)
   const punchSocketClosed = closed(punchSocket)
+  const cleared = handshakeCleared(server, hs)
 
   relaySocket.destroy()
   await withTimeout(
@@ -1200,10 +1216,9 @@ test('relay transport failure while pairing clears a parked handshake', async fu
     'Timed out waiting for relay failure cleanup'
   )
 
-  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
   t.is(a.stats.relaying.aborts, relayAborts + 1, 'server records one relay pairing abort')
 
-  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+  await withTimeout(cleared, 'Timed out waiting for the unpaired handshake to clear')
   t.absent(
     server._holepunches.find((h) => h === hs),
     'server cleared the unpaired handshake'
@@ -1287,6 +1302,7 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
   const relaySocketClosed = closed(relaySocket)
   const relayClientClosed = closed(relayClient)
   const rawStreamClosed = closed(rawStream)
+  const cleared = handshakeCleared(server, hs)
 
   relayClient.destroy(new Error('simulated relay failure'))
   await withTimeout(
@@ -1294,7 +1310,7 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
     'Timed out waiting for paired relay failure cleanup'
   )
 
-  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+  await withTimeout(cleared, 'Timed out waiting for the paired handshake to clear')
   t.absent(
     server._holepunches.find((h) => h === hs),
     'server cleared the paired handshake'
@@ -1302,4 +1318,73 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
   t.is(serverNode.stats.relaying.aborts, relayAborts, 'paired relay loss is not a pairing abort')
 
   socket.destroy()
+})
+
+test('non-punching probes do not extend the relay recovery deadline', async function (t) {
+  const Server = require('../lib/server')
+  const { ERROR, FIREWALL } = require('../lib/constants')
+  const server = new Server(null, { relayRecoveryWait: 30000 })
+
+  // Exercise the real request-completion path without networking or NAT timing.
+  const hs = {
+    round: 0,
+    prepunching: null,
+    activeHolepunchRequests: 0,
+    relayFailedAt: 1000,
+    relayRecoveryTimeout: null,
+    rawStream: {
+      destroyed: false,
+      destroy() {
+        this.destroyed = true
+      }
+    },
+    puncher: {
+      socket: {},
+      remoteHolepunching: false,
+      punching: false,
+      nat: { firewall: FIREWALL.CONSISTENT, freeze() {} },
+      updateRemote() {},
+      async analyze() {
+        return true
+      }
+    },
+    payload: {
+      decrypt: (payload) => payload,
+      encrypt: (payload) => payload,
+      token: () => null
+    }
+  }
+
+  server._holepunches.push(hs)
+  server._announcer = { isRelay: () => false }
+
+  const peerAddress = { host: '127.0.0.1', port: 12345 }
+  const probe = {
+    id: 0,
+    peerAddress,
+    payload: { error: ERROR.NONE, firewall: FIREWALL.CONSISTENT, round: 0, punching: false }
+  }
+  const req = { from: peerAddress, socket: null }
+  const failedAt = hs.relayFailedAt
+  const dateNow = Date.now
+  let now = failedAt
+
+  t.teardown(
+    () => {
+      Date.now = dateNow
+      clearTimeout(hs.relayRecoveryTimeout)
+    },
+    { force: true }
+  )
+  Date.now = () => now
+
+  for (const elapsed of [10000, 20000]) {
+    now = failedAt + elapsed
+    await server._onpeerholepunch(probe, req)
+  }
+  t.absent(hs.rawStream.destroyed, 'probes keep the stream alive within the original grace')
+
+  now = failedAt + server.relayRecoveryWait
+  await server._onpeerholepunch(probe, req)
+  t.ok(hs.rawStream.destroyed, 'request completion cleans up at the original deadline')
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -835,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close())
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -859,7 +859,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     () => {
       delete Nat.prototype.firewall
     },
-    { force: true, order: 10 }
+    { force: true }
   )
 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
@@ -896,7 +896,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy())
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,10 +825,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
-    force: true,
-    order: 0
-  })
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -838,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { force: true, order: -10 })
+  t.teardown(() => relay.close(), { order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -899,7 +896,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { force: true, order: -20 })
+  t.teardown(() => socket.destroy(), { order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -214,6 +214,25 @@ async function waitFor(fn, timeout = 2000) {
   }
 }
 
+async function withTimeout(promise, message) {
+  let timer = null
+
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new Error(message)), 5000)
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+function closed(stream) {
+  return new Promise((resolve) => stream.once('close', resolve))
+}
+
 test('relay connections through node, client side, server aborts hole punch', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -546,7 +565,12 @@ test('relay connection upgrades to direct connection', async function (t) {
   for (const opts of [
     { name: 'default keepalive' },
     { name: 'without keepalive', connectionKeepAlive: false, confirmWithAppData: true },
-    { name: 'idle without keepalive', connectionKeepAlive: false }
+    { name: 'idle without keepalive', connectionKeepAlive: false },
+    {
+      name: 'server relay loss while analyzing',
+      connectionKeepAlive: false,
+      relayFailure: true
+    }
   ]) {
     t.comment(opts.name)
     const { bootstrap } = await swarm(t)
@@ -564,8 +588,10 @@ test('relay connection upgrades to direct connection', async function (t) {
       ephemeral: true,
       connectionKeepAlive: opts.connectionKeepAlive
     })
+    t.teardown(() => Promise.all([relayNode.destroy(), serverNode.destroy(), clientNode.destroy()]))
 
     const resumePunching = pausePunching(t, [serverNode, clientNode])
+    const pausedAnalysis = opts.relayFailure ? pauseAnalysis(t, serverNode, true) : null
 
     const relayServer = new RelayServer({
       createStream(opts) {
@@ -582,6 +608,7 @@ test('relay connection upgrades to direct connection', async function (t) {
     })
 
     const relayTransportServer = relayNode.createServer(function (socket) {
+      if (opts.relayFailure) socket.on('error', () => {})
       relaySockets.push(socket)
       // Wait until both client and server have opened their relay transport sockets.
       if (relaySockets.length === 2) resolveRelaySockets(relaySockets)
@@ -640,7 +667,29 @@ test('relay connection upgrades to direct connection', async function (t) {
 
     const clientUpgraded = once(clientSocket.rawStream, 'remote-changed')
     const serverUpgraded = once(serverSocket.rawStream, 'remote-changed')
-    const relaySocketsClosed = relaySockets.map((socket) => once(socket, 'close'))
+    const relaySocketsClosed = relaySockets.map((socket) =>
+      opts.relayFailure ? closed(socket) : once(socket, 'close')
+    )
+
+    if (pausedAnalysis) {
+      const puncher = await withTimeout(
+        pausedAnalysis.active,
+        'Timed out waiting for the server NAT analysis'
+      )
+      const hs = appServer._holepunches.find((h) => h && h.relayPaired && h.puncher === puncher)
+
+      if (!hs) throw new Error('Missing paired server handshake')
+
+      const relaySocket = hs.relaySocket
+      const relaySocketClosed = closed(relaySocket)
+
+      relaySocket.destroy()
+      await withTimeout(relaySocketClosed, 'Timed out waiting for the server relay socket to close')
+
+      t.ok(!hs.rawStream.destroyed, 'server keeps the recoverable raw stream alive')
+
+      pausedAnalysis.resume()
+    }
 
     resumePunching()
 
@@ -658,8 +707,19 @@ test('relay connection upgrades to direct connection', async function (t) {
       t.alike((await appData)[0], Buffer.from('after upgrade'), 'app data confirms direct path')
     }
 
-    await Promise.all([clientUpgraded, serverUpgraded])
-    await Promise.all(relaySocketsClosed)
+    const upgraded = Promise.all([clientUpgraded, serverUpgraded])
+    if (opts.relayFailure) {
+      await withTimeout(upgraded, 'Timed out waiting for direct upgrade after relay loss')
+    } else {
+      await upgraded
+    }
+
+    const relaysClosed = Promise.all(relaySocketsClosed)
+    if (opts.relayFailure) {
+      await withTimeout(relaysClosed, 'Timed out waiting for relay transports to close')
+    } else {
+      await relaysClosed
+    }
     t.pass('relay transport sockets close after direct upgrade')
 
     t.is(
@@ -676,7 +736,10 @@ test('relay connection upgrades to direct connection', async function (t) {
     if (!opts.confirmWithAppData) {
       const afterUpgrade = once(clientSocket, 'data')
       clientSocket.write(Buffer.from('after upgrade'))
-      t.alike((await afterUpgrade)[0], Buffer.from('after upgrade'), 'direct path carries data')
+      const received = opts.relayFailure
+        ? await withTimeout(afterUpgrade, 'Timed out waiting for data over the direct path')
+        : await afterUpgrade
+      t.alike(received[0], Buffer.from('after upgrade'), 'direct path carries data')
     }
 
     await endAndCloseSocket(clientSocket)
@@ -778,6 +841,39 @@ function pausePunching(t, pausedNodes) {
   return resume
 }
 
+function pauseAnalysis(t, node, remoteHolepunching, stableResult) {
+  const analyze = Holepuncher.prototype.analyze
+
+  let resolveActive
+  const active = new Promise((resolve) => {
+    resolveActive = resolve
+  })
+
+  let unpause
+  const resumed = new Promise((resolve) => {
+    unpause = resolve
+  })
+
+  const resume = () => {
+    unpause()
+    Holepuncher.prototype.analyze = analyze
+  }
+
+  Holepuncher.prototype.analyze = async function (...args) {
+    if (this.dht === node && this.remoteHolepunching === remoteHolepunching) {
+      resolveActive(this)
+      await resumed
+      if (stableResult !== undefined) return stableResult
+    }
+
+    return analyze.call(this, ...args)
+  }
+
+  t.teardown(resume, { force: true })
+
+  return { active, resume }
+}
+
 test.skip('server does not support connection relaying', async function (t) {
   const { bootstrap } = await swarm(t)
 
@@ -816,7 +912,7 @@ test.skip('server does not support connection relaying', async function (t) {
   await c.destroy()
 })
 
-test('relayed TRY_LATER stream close destroys the parked server puncher', async function (t) {
+test('paired relay loss clears parked and in-flight idle handshakes', async function (t) {
   const { bootstrap } = await swarm(t)
 
   const Nat = require('../lib/nat')
@@ -866,10 +962,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
 
-  let resolveTryLater
-  const tryLater = new Promise((resolve) => {
-    resolveTryLater = resolve
-  })
+  let resolveTryLater = null
 
   const server = a.createServer(
     {
@@ -879,7 +972,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
           (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
           a._randomPunches >= a._randomPunchLimit
         ) {
-          resolveTryLater()
+          if (resolveTryLater) resolveTryLater()
         }
         return true
       }
@@ -891,48 +984,87 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
 
   await server.listen()
 
-  const socket = b.connect(server.publicKey, {
-    relayThrough: relayServer.publicKey,
-    localConnection: false,
-    fastOpen: false // a randomizing NAT would eat the fast-open packets
-  })
-  socket.on('error', () => {})
-  t.teardown(() => socket.destroy())
+  for (const relayFailure of ['after TRY_LATER', 'during a non-punching probe']) {
+    t.comment(relayFailure)
 
-  // Relay pairing has cleared the initial punch timeout by the time the
-  // connection is emitted. The holepunch hook runs immediately before the
-  // saturated random-punch budget makes the server reply with TRY_LATER.
-  await Promise.all([once(server, 'connection'), tryLater])
+    const probing = relayFailure.startsWith('during')
+    const tryLater = probing
+      ? null
+      : new Promise((resolve) => {
+          resolveTryLater = resolve
+        })
+    const resumePunching = probing ? pausePunching(t, [a, b]) : null
+    // Keep this request on the normal idle-return path so cleanup must come
+    // from the request's finally block rather than _abort().
+    const pausedAnalysis = probing ? pauseAnalysis(t, a, false, true) : null
 
-  const hs = server._holepunches.find((h) => {
-    const p = h && h.puncher
-    return (
-      p &&
-      h.relayPaired &&
-      h.prepunching === null &&
-      p.remoteHolepunching &&
-      !p.destroyed &&
-      !p.punching &&
-      !p.connected
+    const connection = once(server, 'connection')
+    const socket = b.connect(server.publicKey, {
+      relayThrough: relayServer.publicKey,
+      localConnection: false,
+      fastOpen: false // a randomizing NAT would eat the fast-open packets
+    })
+    socket.on('error', () => {})
+    const socketClosed = closed(socket)
+    t.teardown(() => socket.destroy())
+
+    let activePuncher = null
+    if (pausedAnalysis) {
+      const [, puncher] = await withTimeout(
+        Promise.all([connection, pausedAnalysis.active]),
+        'Timed out waiting for the relayed connection and server NAT analysis'
+      )
+      activePuncher = puncher
+      const updateRemote = puncher.updateRemote
+      puncher.updateRemote = function (state) {
+        return updateRemote.call(this, { ...state, punching: false })
+      }
+    } else {
+      // Relay pairing has cleared the initial punch timeout by the time the
+      // connection is emitted. The hook runs immediately before TRY_LATER.
+      await withTimeout(
+        Promise.all([connection, tryLater]),
+        'Timed out waiting for the relayed connection and TRY_LATER decision'
+      )
+    }
+
+    const hs = server._holepunches.find((h) => {
+      const p = h && h.puncher
+      if (!p || !h.relayPaired || p.destroyed || p.punching || p.connected) return false
+      if (activePuncher) return p === activePuncher
+      return h.prepunching === null && p.remoteHolepunching
+    })
+    if (!hs) throw new Error(`Missing ${activePuncher ? 'in-flight' : 'parked'} handshake`)
+
+    const relaySocketClosed = closed(hs.relaySocket)
+    const rawStream = hs.rawStream
+    const punchSocket = hs.puncher.socket
+    const rawStreamClosed = closed(rawStream)
+    const punchSocketClosed = closed(punchSocket)
+
+    hs.relaySocket.destroy()
+    await withTimeout(relaySocketClosed, 'Timed out waiting for the relay socket to close')
+
+    if (pausedAnalysis) {
+      t.ok(!rawStream.destroyed, 'server defers cleanup during active holepunch processing')
+      pausedAnalysis.resume()
+    }
+
+    await withTimeout(
+      Promise.all([rawStreamClosed, punchSocketClosed]),
+      'Timed out waiting for the raw stream and punch socket to close'
     )
-  })
-  t.ok(hs, 'server parked a live puncher after relay pairing')
-  if (!hs) return
 
-  // Close the relayed raw stream without an error before direct upgrade. The
-  // puncher cleanup must not depend on the raw stream error path.
-  const puncher = hs.puncher
-  const punchSocket = puncher.socket
-  const rawStreamClosed = once(hs.rawStream, 'close')
-  const punchSocketClosed = once(punchSocket, 'close')
+    t.absent(
+      a._socketPool.lookup(punchSocket),
+      `server released the ${probing ? 'in-flight' : 'parked'} punch socket`
+    )
 
-  hs.rawStream.destroy()
-  await Promise.all([rawStreamClosed, punchSocketClosed])
-
-  t.ok(puncher.destroyed, 'server destroyed the parked puncher')
-  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
-
-  socket.destroy()
+    if (resumePunching) resumePunching()
+    resolveTryLater = null
+    socket.destroy()
+    await withTimeout(socketClosed, 'Timed out waiting for the client socket to close')
+  }
 })
 
 test('relay transport failure while pairing clears a parked handshake', async function (t) {
@@ -955,7 +1087,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
     }
   })
 
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close())
 
   // Do not accept the client side, so the server-side relay pair stays pending
   const relayServer = r.createServer(function (socket) {
@@ -981,7 +1113,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
     () => {
       delete Nat.prototype.firewall
     },
-    { force: true, order: 10 }
+    { force: true }
   )
 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
@@ -1019,7 +1151,7 @@ test('relay transport failure while pairing clears a parked handshake', async fu
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy())
 
   // The hook runs immediately before the saturated random-punch budget makes
   // the server reply with TRY_LATER while relay pairing is still pending.
@@ -1047,20 +1179,30 @@ test('relay transport failure while pairing clears a parked handshake', async fu
 
   // Fail relay pairing and observe server cleanup before destroying the client,
   // so client shutdown cannot supply a different cleanup path.
+  const relayAborts = a.stats.relaying.aborts
+  const relaySocket = hs.relaySocket
+  const relayClient = hs.relayClient
   const rawStream = hs.rawStream
   const punchSocket = hs.puncher.socket
-  hs.relaySocket.destroy()
+  const relaySocketClosed = closed(relaySocket)
+  const relayClientClosed = closed(relayClient)
+  const rawStreamClosed = closed(rawStream)
+  const punchSocketClosed = closed(punchSocket)
 
-  await new Promise(setImmediate)
-  await new Promise(setImmediate)
+  relaySocket.destroy()
+  await withTimeout(
+    Promise.all([relaySocketClosed, relayClientClosed, rawStreamClosed, punchSocketClosed]),
+    'Timed out waiting for relay failure cleanup'
+  )
+
+  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
+  t.is(a.stats.relaying.aborts, relayAborts + 1, 'server records one relay pairing abort')
+
   await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
-
-  t.ok(rawStream.destroyed, 'server destroyed the raw stream after relay pairing failed')
   t.absent(
     server._holepunches.find((h) => h === hs),
     'server cleared the unpaired handshake'
   )
-  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
 
   socket.destroy()
 })
@@ -1085,7 +1227,7 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
       return relayNode.createRawStream({ ...opts, framed: true })
     }
   })
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close())
 
   const relayServer = relayNode.createServer(function (socket) {
     socket.on('error', () => {})
@@ -1113,7 +1255,7 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
     localConnection: false
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy())
 
   await connection
 
@@ -1132,18 +1274,26 @@ test('relay transport failure after pairing clears an unrecoverable handshake', 
 
   t.absent(hs.puncher, 'the handshake has no direct-punch recovery path')
 
+  const relayAborts = serverNode.stats.relaying.aborts
+  const relaySocket = hs.relaySocket
+  const relayClient = hs.relayClient
   const rawStream = hs.rawStream
-  hs.relayClient.destroy(new Error('simulated relay failure'))
+  const relaySocketClosed = closed(relaySocket)
+  const relayClientClosed = closed(relayClient)
+  const rawStreamClosed = closed(rawStream)
 
-  await new Promise(setImmediate)
-  await new Promise(setImmediate)
-  t.ok(rawStream.destroyed, 'server destroyed the raw stream after relay transport failed')
+  relayClient.destroy(new Error('simulated relay failure'))
+  await withTimeout(
+    Promise.all([relaySocketClosed, relayClientClosed, rawStreamClosed]),
+    'Timed out waiting for paired relay failure cleanup'
+  )
 
   await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
   t.absent(
     server._holepunches.find((h) => h === hs),
     'server cleared the paired handshake'
   )
+  t.is(serverNode.stats.relaying.aborts, relayAborts, 'paired relay loss is not a pairing abort')
 
   socket.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -814,3 +814,87 @@ test.skip('server does not support connection relaying', async function (t) {
   await b.destroy()
   await c.destroy()
 })
+
+test('relayed client that never wins a punch does not leak the server holepuncher', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const Nat = require('../lib/nat')
+  const { FIREWALL } = require('../lib/constants')
+
+  const r = createDHT({ bootstrap, firewalled: false, ephemeral: true })
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return r.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  const relayServer = r.createServer(function (socket) {
+    socket.on('error', () => {})
+    relay.accept(socket, { id: socket.remotePublicKey }).on('error', () => {})
+  })
+
+  await relayServer.listen()
+
+  // The client classifies as behind a randomizing NAT (like CGNAT), so the
+  // server rate limits the punch. Scoped to the client node only.
+  Object.defineProperty(Nat.prototype, 'firewall', {
+    configurable: true,
+    get() {
+      return this.dht === b ? FIREWALL.RANDOM : this._testFirewall
+    },
+    set(value) {
+      this._testFirewall = value
+    }
+  })
+  t.teardown(() => {
+    delete Nat.prototype.firewall
+  })
+
+  // Saturate the random-punch budget so the punch is postponed with TRY_LATER
+  a._randomPunches = a._randomPunchLimit
+
+  const server = a.createServer(
+    { shareLocalAddress: false, handshakeClearWait: 100 },
+    function (socket) {
+      socket.on('error', () => {})
+    }
+  )
+
+  await server.listen()
+
+  const socket = b.connect(server.publicKey, {
+    relayThrough: relayServer.publicKey,
+    localConnection: false,
+    fastOpen: false // a randomizing NAT would eat the fast-open packets
+  })
+  socket.on('error', () => {})
+
+  // Relay pairing has cleared the initial punch timeout by the time the
+  // connection is emitted, so the postponed puncher is parked
+  const [serverSocket] = await once(server, 'connection')
+  serverSocket.on('error', () => {})
+
+  const hs = server._holepunches.find((h) => h && h.puncher)
+  t.ok(
+    hs !== undefined && hs.prepunching === null,
+    'server parked a puncher for the postponed punch'
+  )
+  t.ok(!hs.puncher.destroyed, 'puncher still holds its socket')
+
+  // A graceful close can land before any relay error propagates, so the
+  // puncher cleanup must not depend on the raw stream error path
+  const punchSocket = hs.puncher.socket
+  hs.rawStream.destroy()
+
+  await once(punchSocket, 'close')
+  t.is(a._socketPool._sockets.size, 0, 'no orphaned holepunch sockets on the server')
+
+  await server.close()
+  await relayServer.close()
+  await Promise.all([r.destroy(), a.destroy(), b.destroy()])
+})

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,7 +825,10 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
+    force: true,
+    order: 0
+  })
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -835,7 +838,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { order: -10 })
+  t.teardown(() => relay.close(), { force: true, order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -896,7 +899,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { order: -20 })
+  t.teardown(() => socket.destroy(), { force: true, order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted. The holepunch hook runs immediately before the
@@ -923,11 +926,10 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const puncher = hs.puncher
   const punchSocket = puncher.socket
   const rawStreamClosed = once(hs.rawStream, 'close')
+  const punchSocketClosed = once(punchSocket, 'close')
 
   hs.rawStream.destroy()
-  await rawStreamClosed
-  await new Promise(setImmediate)
-  await new Promise(setImmediate)
+  await Promise.all([rawStreamClosed, punchSocketClosed])
 
   t.ok(puncher.destroyed, 'server destroyed the parked puncher')
   t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -1,4 +1,5 @@
 const test = require('brittle')
+const b4a = require('b4a')
 const { once } = require('events')
 const RelayServer = require('blind-relay').Server
 const NoiseSecretStream = require('@hyperswarm/secret-stream')
@@ -930,6 +931,219 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
 
   t.ok(puncher.destroyed, 'server destroyed the parked puncher')
   t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
+
+  socket.destroy()
+})
+
+test('relay transport failure while pairing clears a parked handshake', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const Nat = require('../lib/nat')
+  const { FIREWALL } = require('../lib/constants')
+
+  const r = createDHT({ bootstrap, firewalled: false, ephemeral: true })
+  const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
+
+  await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return r.createRawStream({ ...opts, framed: true })
+    }
+  })
+
+  t.teardown(() => relay.close(), { order: -10 })
+
+  // Do not accept the client side, so the server-side relay pair stays pending
+  const relayServer = r.createServer(function (socket) {
+    socket.on('error', () => {})
+    if (b4a.equals(socket.remotePublicKey, b.defaultKeyPair.publicKey)) return
+    relay.accept(socket, { id: socket.remotePublicKey }).on('error', () => {})
+  })
+
+  await relayServer.listen()
+
+  // The client classifies as behind a randomizing NAT (like CGNAT), so the
+  // server rate limits the punch. Scoped to the client node only.
+  Object.defineProperty(Nat.prototype, 'firewall', {
+    configurable: true,
+    get() {
+      return this.dht === b ? FIREWALL.RANDOM : this._testFirewall
+    },
+    set(value) {
+      this._testFirewall = value
+    }
+  })
+  t.teardown(
+    () => {
+      delete Nat.prototype.firewall
+    },
+    { force: true, order: 10 }
+  )
+
+  // Saturate the random-punch budget so the punch is postponed with TRY_LATER
+  a._randomPunches = a._randomPunchLimit
+
+  let resolveTryLater
+  const tryLater = new Promise((resolve) => {
+    resolveTryLater = resolve
+  })
+
+  const server = a.createServer(
+    {
+      shareLocalAddress: false,
+      handshakeClearWait: 100,
+      holepunch(remoteFirewall, localFirewall) {
+        if (
+          (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
+          a._randomPunches >= a._randomPunchLimit
+        ) {
+          resolveTryLater()
+        }
+        return true
+      }
+    },
+    function (socket) {
+      socket.on('error', () => {})
+    }
+  )
+
+  await server.listen()
+
+  const socket = b.connect(server.publicKey, {
+    relayThrough: relayServer.publicKey,
+    localConnection: false,
+    fastOpen: false // a randomizing NAT would eat the fast-open packets
+  })
+  socket.on('error', () => {})
+  t.teardown(() => socket.destroy(), { order: -20 })
+
+  // The hook runs immediately before the saturated random-punch budget makes
+  // the server reply with TRY_LATER while relay pairing is still pending.
+  await tryLater
+
+  const hs = server._holepunches.find((h) => {
+    if (!h || !h.puncher) return false
+    const p = h.puncher
+    return (
+      !h.relayPaired &&
+      !h.aborted &&
+      h.prepunching === null &&
+      h.relaySocket &&
+      !h.relaySocket.destroyed &&
+      h.rawStream &&
+      !h.rawStream.destroyed &&
+      p.remoteHolepunching &&
+      !p.destroyed &&
+      !p.punching &&
+      !p.connected
+    )
+  })
+  t.ok(hs, 'server parked a live puncher while relay pairing was pending')
+  if (!hs) return
+
+  // Fail relay pairing and observe server cleanup before destroying the client,
+  // so client shutdown cannot supply a different cleanup path.
+  const rawStream = hs.rawStream
+  const punchSocket = hs.puncher.socket
+  hs.relaySocket.destroy()
+
+  await new Promise(setImmediate)
+  await new Promise(setImmediate)
+  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+
+  t.ok(rawStream.destroyed, 'server destroyed the raw stream after relay pairing failed')
+  t.absent(
+    server._holepunches.find((h) => h === hs),
+    'server cleared the unpaired handshake'
+  )
+  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
+
+  socket.destroy()
+})
+
+test('relay transport failure after pairing clears an unrecoverable handshake', async function (t) {
+  const { bootstrap } = await swarm(t)
+
+  const relayNode = createDHT({ bootstrap, firewalled: false, ephemeral: true })
+  const serverNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+  const clientNode = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
+
+  t.teardown(() => Promise.all([relayNode.destroy(), serverNode.destroy(), clientNode.destroy()]))
+
+  await Promise.all([
+    relayNode.fullyBootstrapped(),
+    serverNode.fullyBootstrapped(),
+    clientNode.fullyBootstrapped()
+  ])
+
+  const relay = new RelayServer({
+    createStream(opts) {
+      return relayNode.createRawStream({ ...opts, framed: true })
+    }
+  })
+  t.teardown(() => relay.close(), { order: -10 })
+
+  const relayServer = relayNode.createServer(function (socket) {
+    socket.on('error', () => {})
+    relay.accept(socket, { id: socket.remotePublicKey }).on('error', () => {})
+  })
+  await relayServer.listen()
+
+  const server = serverNode.createServer(
+    {
+      relayThrough: relayServer.publicKey,
+      shareLocalAddress: false,
+      holepunch: false,
+      handshakeClearWait: 100
+    },
+    function (socket) {
+      socket.on('error', () => {})
+    }
+  )
+  await server.listen()
+
+  const connection = once(server, 'connection')
+  const socket = clientNode.connect(server.publicKey, {
+    relayThrough: relayServer.publicKey,
+    fastOpen: false,
+    localConnection: false
+  })
+  socket.on('error', () => {})
+  t.teardown(() => socket.destroy(), { order: -20 })
+
+  await connection
+
+  const hs = server._holepunches.find(
+    (h) =>
+      h &&
+      h.relayPaired &&
+      !h.aborted &&
+      h.relaySocket &&
+      h.relayClient &&
+      h.rawStream &&
+      !h.rawStream.destroyed
+  )
+  t.ok(hs, 'server established the relayed handshake')
+  if (!hs) return
+
+  t.absent(hs.puncher, 'the handshake has no direct-punch recovery path')
+
+  const rawStream = hs.rawStream
+  hs.relayClient.destroy(new Error('simulated relay failure'))
+
+  await new Promise(setImmediate)
+  await new Promise(setImmediate)
+  t.ok(rawStream.destroyed, 'server destroyed the raw stream after relay transport failed')
+
+  await new Promise((resolve) => setTimeout(resolve, server.handshakeClearWait * 1.2))
+  t.absent(
+    server._holepunches.find((h) => h === hs),
+    'server cleared the paired handshake'
+  )
 
   socket.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -815,7 +815,7 @@ test.skip('server does not support connection relaying', async function (t) {
   await c.destroy()
 })
 
-test('relayed client that never wins a punch does not leak the server holepuncher', async function (t) {
+test('relayed TRY_LATER stream close destroys the parked server puncher', async function (t) {
   const { bootstrap } = await swarm(t)
 
   const Nat = require('../lib/nat')
@@ -825,6 +825,11 @@ test('relayed client that never wins a punch does not leak the server holepunche
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
+    force: true,
+    order: 0
+  })
+
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
   const relay = new RelayServer({
@@ -832,6 +837,8 @@ test('relayed client that never wins a punch does not leak the server holepunche
       return r.createRawStream({ ...opts, framed: true })
     }
   })
+
+  t.teardown(() => relay.close(), { force: true, order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -851,9 +858,12 @@ test('relayed client that never wins a punch does not leak the server holepunche
       this._testFirewall = value
     }
   })
-  t.teardown(() => {
-    delete Nat.prototype.firewall
-  })
+  t.teardown(
+    () => {
+      delete Nat.prototype.firewall
+    },
+    { force: true, order: 10 }
+  )
 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
@@ -873,28 +883,29 @@ test('relayed client that never wins a punch does not leak the server holepunche
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
+  t.teardown(() => socket.destroy(), { force: true, order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
   // connection is emitted, so the postponed puncher is parked
-  const [serverSocket] = await once(server, 'connection')
-  serverSocket.on('error', () => {})
+  await once(server, 'connection')
 
-  const hs = server._holepunches.find((h) => h && h.puncher)
-  t.ok(
-    hs !== undefined && hs.prepunching === null,
-    'server parked a puncher for the postponed punch'
-  )
-  t.ok(!hs.puncher.destroyed, 'puncher still holds its socket')
+  const hs = server._holepunches.find((h) => {
+    const p = h && h.puncher
+    return (
+      p && h.relayPaired && h.prepunching === null && !p.destroyed && !p.punching && !p.connected
+    )
+  })
+  t.ok(hs, 'server parked a live puncher after relay pairing')
+  if (!hs) return
 
-  // A graceful close can land before any relay error propagates, so the
-  // puncher cleanup must not depend on the raw stream error path
+  // Close the relayed raw stream without an error before direct upgrade. The
+  // puncher cleanup must not depend on the raw stream error path.
   const punchSocket = hs.puncher.socket
   hs.rawStream.destroy()
 
-  await once(punchSocket, 'close')
-  t.is(a._socketPool._sockets.size, 0, 'no orphaned holepunch sockets on the server')
+  await waitFor(() => hs.puncher.destroyed && !a._socketPool.lookup(punchSocket))
+  t.ok(hs.puncher.destroyed, 'server destroyed the parked puncher')
+  t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
 
-  await server.close()
-  await relayServer.close()
-  await Promise.all([r.destroy(), a.destroy(), b.destroy()])
+  socket.destroy()
 })

--- a/test/relaying.js
+++ b/test/relaying.js
@@ -825,10 +825,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   const a = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
   const b = createDHT({ bootstrap, quickFirewall: false, ephemeral: true })
 
-  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]), {
-    force: true,
-    order: 0
-  })
+  t.teardown(() => Promise.all([r.destroy(), a.destroy(), b.destroy()]))
 
   await Promise.all([r.fullyBootstrapped(), a.fullyBootstrapped(), b.fullyBootstrapped()])
 
@@ -838,7 +835,7 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     }
   })
 
-  t.teardown(() => relay.close(), { force: true, order: -10 })
+  t.teardown(() => relay.close(), { order: -10 })
 
   const relayServer = r.createServer(function (socket) {
     socket.on('error', () => {})
@@ -868,8 +865,24 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
   // Saturate the random-punch budget so the punch is postponed with TRY_LATER
   a._randomPunches = a._randomPunchLimit
 
+  let resolveTryLater
+  const tryLater = new Promise((resolve) => {
+    resolveTryLater = resolve
+  })
+
   const server = a.createServer(
-    { shareLocalAddress: false, handshakeClearWait: 100 },
+    {
+      shareLocalAddress: false,
+      holepunch(remoteFirewall, localFirewall) {
+        if (
+          (remoteFirewall >= FIREWALL.RANDOM || localFirewall >= FIREWALL.RANDOM) &&
+          a._randomPunches >= a._randomPunchLimit
+        ) {
+          resolveTryLater()
+        }
+        return true
+      }
+    },
     function (socket) {
       socket.on('error', () => {})
     }
@@ -883,16 +896,23 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
     fastOpen: false // a randomizing NAT would eat the fast-open packets
   })
   socket.on('error', () => {})
-  t.teardown(() => socket.destroy(), { force: true, order: -20 })
+  t.teardown(() => socket.destroy(), { order: -20 })
 
   // Relay pairing has cleared the initial punch timeout by the time the
-  // connection is emitted, so the postponed puncher is parked
-  await once(server, 'connection')
+  // connection is emitted. The holepunch hook runs immediately before the
+  // saturated random-punch budget makes the server reply with TRY_LATER.
+  await Promise.all([once(server, 'connection'), tryLater])
 
   const hs = server._holepunches.find((h) => {
     const p = h && h.puncher
     return (
-      p && h.relayPaired && h.prepunching === null && !p.destroyed && !p.punching && !p.connected
+      p &&
+      h.relayPaired &&
+      h.prepunching === null &&
+      p.remoteHolepunching &&
+      !p.destroyed &&
+      !p.punching &&
+      !p.connected
     )
   })
   t.ok(hs, 'server parked a live puncher after relay pairing')
@@ -900,11 +920,16 @@ test('relayed TRY_LATER stream close destroys the parked server puncher', async 
 
   // Close the relayed raw stream without an error before direct upgrade. The
   // puncher cleanup must not depend on the raw stream error path.
-  const punchSocket = hs.puncher.socket
-  hs.rawStream.destroy()
+  const puncher = hs.puncher
+  const punchSocket = puncher.socket
+  const rawStreamClosed = once(hs.rawStream, 'close')
 
-  await waitFor(() => hs.puncher.destroyed && !a._socketPool.lookup(punchSocket))
-  t.ok(hs.puncher.destroyed, 'server destroyed the parked puncher')
+  hs.rawStream.destroy()
+  await rawStreamClosed
+  await new Promise(setImmediate)
+  await new Promise(setImmediate)
+
+  t.ok(puncher.destroyed, 'server destroyed the parked puncher')
   t.absent(a._socketPool.lookup(punchSocket), 'server released the parked punch socket')
 
   socket.destroy()


### PR DESCRIPTION
Fixes failure modes

1. **Relay pairing fails while the punch is parked.** The client was told `TRY_LATER`, which clears the prepunch timer and re-arms nothing. If relay pairing then times out or errors and the client never comes back, the raw stream was never connected and never emits `close`: the handshake, its puncher and the puncher's pool socket leaked until restart. This is the remaining `socketPool` growth after #291 (hopefully).
2. **Relay dies after pairing succeeded**. The server stopped watching the relay once pairing completed, so it never noticed the relay going away. Under the default keepalive this self-heals: the dead connection times out and clears itself. Only with connectionKeepAlive: false does nothing time out, so the handshake leaks permanently.

Co-authored with AI