### PR TITLE
Ignore client-claimed peerAddress on direct handshakes

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,10 +112,14 @@ Options include:
 
 ```js
 {
-  firewall (remotePublicKey, remoteHandshakePayload) {
+  firewall (remotePublicKey, remoteHandshakePayload, clientAddress) {
     // validate if you want a connection from remotePublicKey
     // if you do return false, else return true
     // remoteHandshakePayload contains their ip and some more info
+    // clientAddress is their observed address. For handshakes received
+    // directly this is the transport source address, but for handshakes
+    // received via a relay it is asserted by the relaying node and is NOT
+    // authenticated - do not use it for access control in that case
     return true
   }
 }

--- a/lib/router.js
+++ b/lib/router.js
@@ -91,7 +91,11 @@ module.exports = class Router {
     if (isServer) {
       let reply = null
       try {
-        reply = noise && (await state.onpeerhandshake({ noise, peerAddress }, req))
+        // A client connecting directly must not assert its own address, so
+        // ignore any peerAddress claimed in a FROM_CLIENT handshake - only
+        // relay hops may set it (and even then it remains unauthenticated)
+        const claimedAddress = mode === FROM_CLIENT ? null : peerAddress
+        reply = noise && (await state.onpeerhandshake({ noise, peerAddress: claimedAddress }, req))
       } catch (e) {
         safetyCatch(e)
         return

--- a/test/connections.js
+++ b/test/connections.js
@@ -978,6 +978,49 @@ test('peer cant flood w/ handshakes', async function (t) {
   await server.close()
 })
 
+test('direct handshake cannot claim a forged peer address', async function (t) {
+  const [a, b] = await swarm(t, 2)
+
+  const seen = []
+  const server = a.createServer({
+    firewall(remotePublicKey, remotePayload, clientAddress) {
+      seen.push(clientAddress)
+      return false
+    }
+  })
+  await server.listen()
+
+  const handshake = new NoiseWrap(b.defaultKeyPair, server.publicKey)
+  const rawStream = b.createRawStream({ framed: true, firewall: () => false })
+  const noise = await handshake.send({
+    error: ERROR.NONE,
+    firewall: FIREWALL.UNKNOWN,
+    holepunch: null,
+    addresses4: [],
+    addresses6: [],
+    udx: { reusableSocket: false, id: rawStream.id, seq: 0 },
+    secretStream: {},
+    relayThrough: null
+  })
+
+  const target = unslabbedHash(server.publicKey)
+  const to = { host: server.address().host, port: server.address().port }
+  const forged = { host: '10.9.9.9', port: 1234 }
+
+  await b._router.peerHandshake(target, { noise, peerAddress: forged, socket: null }, to)
+
+  t.is(seen.length, 1, 'firewall hook was called')
+  t.is(seen[0].host, '127.0.0.1', 'firewall hook saw the real transport host, not the forged one')
+  t.is(
+    seen[0].port,
+    b.address().port,
+    'firewall hook saw the real transport port, not the forged one'
+  )
+
+  rawStream.destroy()
+  await server.close()
+})
+
 test('handshakes that arrive while the server is suspended are cleared', async function (t) {
   const [a] = await swarm(t)
 


### PR DESCRIPTION
Closes #295

## Problem

When a client sends a `PEER_HANDSHAKE` request **directly** to a server (mode `FROM_CLIENT`), the `peerAddress` field of the wire message is fully attacker-controlled, yet `Router.onpeerhandshake` passed it straight through to `Server._onpeerhandshake`, which used it as `clientAddress = peerAddress || req.from` (`lib/server.js:497`). Consequences:

1. **Firewall-hook bypass**: `clientAddress` is passed to the application's `firewall(remotePublicKey, remotePayload, clientAddress)` hook. Any app doing IP-based allow/deny or per-IP rate limiting was bypassable — the attacker simply asserts a trusted address. Reproduced: a deny-all-except-`10.9.9.9` hook received `{ host: '10.9.9.9', port: 1234 }` from a handshake sent by `127.0.0.1`.
2. **Forced resource allocation on OPEN servers**: forging `peerAddress` flips `direct = !peerAddress` to false, and via the LAN branch (`lib/server.js:436-450`, attacker sets `peerAddress.host` to the server's own IP plus private ranges in `addresses4`) forces `Holepuncher` + fresh UDP socket allocation even on non-firewalled servers, bypassing the `ourRemoteAddr` skip.

## Fix

In `Router.onpeerhandshake`, ignore the wire `peerAddress` when a `FROM_CLIENT` handshake is delivered directly to a server, so the server falls back to `req.from` (the actual transport source). Relay hops (`FROM_RELAY` / `FROM_SECOND_RELAY`) still set it — the legitimate client never sends it (`peerHandshake()` only sends `{ noise, socket, session }`, `lib/connect.js:460-463`).

This also kills variant (2): direct handshakes now always take the `direct` path with the real source address.

## Not fixed here (documented instead)

For **relayed** handshakes, `peerAddress` is asserted by the relaying node — and an attacker can also send a `FROM_RELAY` message to a server directly, claiming to be a relay. So `clientAddress` remains unauthenticated whenever the handshake did not arrive directly from the client. Binding relayed handshakes to the relay cryptographically is a larger protocol change; this PR documents the trust property in the README firewall option instead.

## Tests

- New test `direct handshake cannot claim a forged peer address` in `test/connections.js`: crafts a valid Noise msg1, sends it directly with forged `peerAddress`, asserts the firewall hook sees the real transport address.
- Full suite passes (`node test/all.js`, 94/94).
