### PR TITLE
Cap concurrent incoming handshakes per server

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,9 @@ Options include:
 
 ```js
 {
+  // max number of concurrent incoming handshakes - additional
+  // handshakes are dropped to shed load, defaults to 256
+  maxConcurrentHandshakes: 256,
   firewall (remotePublicKey, remoteHandshakePayload) {
     // validate if you want a connection from remotePublicKey
     // if you do return false, else return true

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,9 @@ exports.FIREWALL = {
   RANDOM: 3
 }
 
+// Max concurrent incoming handshakes per server before new ones are dropped
+exports.MAX_CONCURRENT_HANDSHAKES = 256
+
 exports.ERROR = {
   // noise / connection related
   NONE: 0,

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@ const b4a = require('b4a')
 const relay = require('blind-relay')
 const NoiseWrap = require('./noise-wrap')
 const Announcer = require('./announcer')
-const { FIREWALL, ERROR } = require('./constants')
+const { FIREWALL, ERROR, MAX_CONCURRENT_HANDSHAKES } = require('./constants')
 const { unslabbedHash } = require('./crypto')
 const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
@@ -37,6 +37,7 @@ module.exports = class Server extends EventEmitter {
     this.createSecretStream = opts.createSecretStream || defaultCreateSecretStream
     this.suspended = false
     this.handshakeClearWait = opts.handshakeClearWait || HANDSHAKE_CLEAR_WAIT
+    this.maxConcurrentHandshakes = opts.maxConcurrentHandshakes || MAX_CONCURRENT_HANDSHAKES
 
     this._shareLocalAddress = opts.shareLocalAddress !== false
     this._reusableSocket = !!opts.reusableSocket
@@ -494,6 +495,9 @@ module.exports = class Server extends EventEmitter {
     // a malicious peer from flooding us with handshakes.
     let p = this._connects.get(k)
     if (!p) {
+      // Shed load once we are at capacity - every handshake allocates state,
+      // a raw stream and potentially a holepunch socket, all held for seconds
+      if (this._connects.size >= this.maxConcurrentHandshakes) return null
       p = this._addHandshake(k, noise, peerAddress || req.from, req, !peerAddress)
       this._connects.set(k, p)
     }

--- a/test/connections.js
+++ b/test/connections.js
@@ -4,7 +4,7 @@ const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
 const DHT = require('../')
 const NoiseWrap = require('../lib/noise-wrap')
-const { FIREWALL, ERROR } = require('../lib/constants')
+const { FIREWALL, ERROR, MAX_CONCURRENT_HANDSHAKES } = require('../lib/constants')
 const { unslabbedHash } = require('../lib/crypto')
 
 test('createServer + connect - once defaults', async function (t) {
@@ -975,6 +975,46 @@ test('peer cant flood w/ handshakes', async function (t) {
   t.is(server._holepunches.length, 1, 'server only registered 1 holepunch')
 
   rawStream.destroy()
+  await server.close()
+})
+
+test('server caps concurrent handshakes', async function (t) {
+  const [a, b] = await swarm(t, 2)
+
+  t.is(a.createServer().maxConcurrentHandshakes, MAX_CONCURRENT_HANDSHAKES, 'expected default')
+
+  const server = a.createServer({ maxConcurrentHandshakes: 4 })
+  await server.listen()
+
+  const req = {
+    to: server.address(),
+    from: { host: '127.0.0.1', port: b.address().port },
+    socket: null
+  }
+
+  let replied = 0
+  for (let i = 0; i < 20; i++) {
+    const handshake = new NoiseWrap(b.defaultKeyPair, server.publicKey)
+    const noise = await handshake.send({
+      error: ERROR.NONE,
+      firewall: FIREWALL.UNKNOWN,
+      holepunch: null,
+      addresses4: [],
+      addresses6: [],
+      udx: { reusableSocket: false, id: 0, seq: 0 },
+      secretStream: {},
+      relayThrough: null
+    })
+
+    // simulate a relayed handshake so the server does not take the direct path
+    const peerAddress = { host: '127.0.0.1', port: b.address().port }
+    if (await server._onpeerhandshake({ noise, peerAddress }, req)) replied++
+  }
+
+  t.is(replied, 4, 'only handshakes up to the cap were processed')
+  t.is(server._connects.size, 4, 'connects are bounded by the cap')
+  t.is(server._holepunches.length, 4, 'holepunch slots are bounded by the cap')
+
   await server.close()
 })
 


### PR DESCRIPTION
Closes #294

## Problem

Inbound `PEER_HANDSHAKE` requests had no admission control. The only flood protection deduped *byte-identical* Noise messages (`lib/server.js:490-499`), which is trivially bypassed by re-randomizing the Noise ephemeral. Each distinct, valid msg1 — offline-craftable, since Noise IK message 1 only needs the server's publicly announced key — caused the server to allocate, per message, retained for 10–20s:

- handshake state + a `_holepunches` slot,
- a UDX raw stream (`lib/server.js:293`),
- for firewalled servers (the default), a `Holepuncher` holding its **own bound UDP socket** (`lib/holepuncher.js:14` → `lib/socket-pool.js:115-121`), plus up to 4 NAT-sample pings at unrelated DHT nodes (`lib/nat.js:42-59`).

At ~100 packets/sec this is ~1,000 live UDP sockets per 10s window → fd exhaustion (EMFILE) within seconds on default ulimits, memory growth, and ~1:4 unsolicited amplification toward DHT infrastructure. Reproduced on a local testnet: 100 valid handshakes → exactly 100 sockets / 100 raw streams / 100 app-level connections, no cap.

## Fix

New `maxConcurrentHandshakes` server option (default **256**). When the in-flight handshake set (`_connects`, which already tracks every live attempt and is reaped by the existing `_clearLater` logic) is full, new handshakes are dropped **before anything is allocated**:

```js
if (this._connects.size >= this.maxConcurrentHandshakes) return null
```

One guard covers every downstream allocation (state, raw stream, puncher socket, NAT samples), since they all happen inside `_addHandshake`. Dropping is silent load-shedding: legitimate clients retry via the normal flow and succeed once entries clear (≤ 10–20s).

## Deliberately not in this PR

- **Per-IP rate limiting**: for relayed handshakes the source is the relay, and the relay-asserted `clientAddress` is unauthenticated (see #295) — a per-IP limiter would throttle honest relays and not stop an attacker asserting fresh addresses. The global cap is the robust backstop; per-source limits can be revisited if relay authentication ever lands.
- **Lazy `Holepuncher` creation** (defer socket allocation until the first authenticated holepunch message): bigger change to the punch state machine; viable follow-up that would cut the per-handshake cost further.

## Tests

- New test `server caps concurrent handshakes` in `test/connections.js`: 20 distinct valid handshakes against a server with `maxConcurrentHandshakes: 4` → exactly 4 processed, `_connects`/`_holepunches` bounded at 4; default value asserted at 256.
- Full suite passes (`node test/all.js`, 94/94).

## Open question for maintainers

Default of 256 is a judgment call: worst case ~256 puncher sockets held ≤ 20s. Happy to adjust (or derive it from available fds) if you prefer something more conservative.
