### PR TITLE
Bound client-chosen relay connections and peer probe address lists

### DIFF
--- a/lib/connect.js
+++ b/lib/connect.js
@@ -14,7 +14,7 @@ const {
   confirmDirectUpgrade,
   destroyRelayConnection
 } = require('./relay-connection')
-const { FIREWALL, ERROR } = require('./constants')
+const { FIREWALL, ERROR, MAX_REMOTE_ADDRESSES } = require('./constants')
 const { unslabbedHash } = require('./crypto')
 const {
   CANNOT_HOLEPUNCH,
@@ -586,7 +586,7 @@ async function updateHolepunch(c, peerAddress, relayAddr, payload) {
   c.puncher.updateRemote({
     punching,
     firewall,
-    addresses,
+    addresses: addresses ? addresses.slice(0, MAX_REMOTE_ADDRESSES) : addresses,
     verified: echoed ? peerAddress.host : null
   })
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,12 @@ exports.FIREWALL = {
   RANDOM: 3
 }
 
+// Max concurrent outbound connections to client-chosen (unauthenticated) relays
+exports.MAX_RELAYING = 32
+
+// Max peer-supplied addresses used as holepunch probe targets
+exports.MAX_REMOTE_ADDRESSES = 16
+
 exports.ERROR = {
   // noise / connection related
   NONE: 0,

--- a/lib/server.js
+++ b/lib/server.js
@@ -5,7 +5,7 @@ const b4a = require('b4a')
 const relay = require('blind-relay')
 const NoiseWrap = require('./noise-wrap')
 const Announcer = require('./announcer')
-const { FIREWALL, ERROR } = require('./constants')
+const { FIREWALL, ERROR, MAX_RELAYING, MAX_REMOTE_ADDRESSES } = require('./constants')
 const { unslabbedHash } = require('./crypto')
 const SecurePayload = require('./secure-payload')
 const Holepuncher = require('./holepuncher')
@@ -45,6 +45,7 @@ module.exports = class Server extends EventEmitter {
     this._announcer = null
     this._connects = new Map()
     this._holepunches = []
+    this._relaying = 0
     this._listening = null
     this._closing = null
   }
@@ -542,7 +543,12 @@ module.exports = class Server extends EventEmitter {
 
     if (round >= h.round) {
       h.round = round
-      p.updateRemote({ punching, firewall, addresses, verified: echoed ? peerAddress.host : null })
+      p.updateRemote({
+        punching,
+        firewall,
+        addresses: addresses ? addresses.slice(0, MAX_REMOTE_ADDRESSES) : addresses,
+        verified: echoed ? peerAddress.host : null
+      })
     }
 
     // Wait for the analyzer to reach a conclusion...
@@ -655,6 +661,22 @@ module.exports = class Server extends EventEmitter {
   _relayConnection(hs, relayThrough, remotePayload, h) {
     this.dht.stats.relaying.attempts++
 
+    // Client-chosen relays are unauthenticated, so bound how many concurrent
+    // outbound connections we make for them before they finish pairing
+    let bounded = false
+    if (!relayThrough) {
+      if (this._relaying >= MAX_RELAYING) return
+      this._relaying++
+      bounded = true
+    }
+
+    const unbind = () => {
+      if (bounded) {
+        bounded = false
+        this._relaying--
+      }
+    }
+
     let isInitiator
     let publicKey
     let token
@@ -679,6 +701,7 @@ module.exports = class Server extends EventEmitter {
       .pair(isInitiator, token, hs.rawStream)
       .on('error', onabort)
       .on('data', (remoteId) => {
+        unbind()
         if (hs.relayTimeout) clearRelayTimeout(hs)
         if (hs.rawStream === null) {
           onabort(null)
@@ -707,6 +730,7 @@ module.exports = class Server extends EventEmitter {
 
     const dht = this.dht
     function onabort() {
+      unbind()
       if (!hs.relayPaired) dht.stats.relaying.aborts++
       destroyRelayConnection(hs)
       if (hs.aborted && hs.rawStream) hs.rawStream.destroy()

--- a/test/connections.js
+++ b/test/connections.js
@@ -2,9 +2,10 @@ const test = require('brittle')
 const { swarm, createDHT, endAndCloseSocket } = require('./helpers')
 const { encode } = require('hypercore-id-encoding')
 const { once } = require('events')
+const b4a = require('b4a')
 const DHT = require('../')
 const NoiseWrap = require('../lib/noise-wrap')
-const { FIREWALL, ERROR } = require('../lib/constants')
+const { FIREWALL, ERROR, MAX_RELAYING } = require('../lib/constants')
 const { unslabbedHash } = require('../lib/crypto')
 
 test('createServer + connect - once defaults', async function (t) {
@@ -976,6 +977,53 @@ test('peer cant flood w/ handshakes', async function (t) {
 
   rawStream.destroy()
   await server.close()
+})
+
+test('server bounds client-chosen relay connections', async function (t) {
+  const [a, b] = await swarm(t, 2)
+
+  const relayTarget = b.createServer()
+  await relayTarget.listen()
+
+  const server = a.createServer()
+  await server.listen()
+
+  let dials = 0
+  const origConnect = a.connect.bind(a)
+  a.connect = (...args) => {
+    dials++
+    return origConnect(...args)
+  }
+
+  const req = {
+    to: server.address(),
+    from: { host: '127.0.0.1', port: b.address().port },
+    socket: null
+  }
+
+  for (let i = 0; i < MAX_RELAYING + 8; i++) {
+    const handshake = new NoiseWrap(b.defaultKeyPair, server.publicKey)
+    const noise = await handshake.send({
+      error: ERROR.NONE,
+      firewall: FIREWALL.UNKNOWN,
+      holepunch: null,
+      addresses4: [],
+      addresses6: [],
+      udx: { reusableSocket: false, id: 0, seq: 0 },
+      secretStream: {},
+      relayThrough: { publicKey: relayTarget.publicKey, token: b4a.alloc(32) }
+    })
+
+    // simulate a relayed handshake so the server does not take the direct path
+    const peerAddress = { host: '127.0.0.1', port: b.address().port }
+    await server._onpeerhandshake({ noise, peerAddress }, req)
+  }
+
+  t.is(dials, MAX_RELAYING, 'outbound connections for client-chosen relays are bounded')
+  t.is(server._relaying, MAX_RELAYING, 'in-flight counter tracks the bound')
+
+  await server.close()
+  await relayTarget.close()
 })
 
 test('handshakes that arrive while the server is suspended are cleared', async function (t) {


### PR DESCRIPTION
Closes #296

## Problem

Two unauthenticated/weakly-authenticated paths let a remote peer make a hyperdht server send traffic or open connections toward attacker-chosen destinations:

1. **Client-supplied `relayThrough` forces arbitrary outbound connections.** A handshake payload containing `relayThrough: { publicKey, token }` made the server unconditionally run `this.dht.connect(publicKey)` (`lib/server.js:655-676`) — a full findPeer DHT fan-out, handshake attempts, streams, keepalives and a 15s timeout — per single inbound handshake packet, repeatable at packet rate, to any 32-byte key. Reproduced: 20 handshake packets → exactly 20 outbound `dht.connect()` calls. This is a reflection/hammering primitive against a victim key and burns the server's own resources.

2. **Peer-supplied probe address lists.** A peer claiming `punching: true` with arbitrary `addresses` in its (encrypted) holepunch payload made the other side send 1-byte UDP probes to those addresses (`lib/holepuncher.js:215-231`). The random-NAT probe variants are properly gated by `_randomPunchLimit`, but the consistent-probe path was not bounded beyond the handshake rate.

## Fix

- **Bound in-flight client-chosen relays** (`lib/server.js`): a new `MAX_RELAYING = 32` bound on concurrent *unpaired* client-chosen relay dials. The counter increments only for the unauthenticated case (`remotePayload.relayThrough`) and is released when pairing completes or the attempt aborts/times out. When the bound is hit, the server simply falls through to the normal holepunch flow (the connection can still succeed directly). The server's **own** configured `relayThrough` is not bounded — that's an authenticated, operator-configured path.
- **Cap probe targets** (`lib/server.js`, `lib/connect.js`): peer-supplied `addresses` lists are sliced to `MAX_REMOTE_ADDRESSES = 16` before being handed to `updateRemote`, on both the server and client side (the client side is post-authentication, but a malicious peer is still worth bounding).

Deliberately out of scope (noted in the issue): the spoofed-source direct fast path (its `clientAddress` becomes the real transport source once #295 lands, so exploitation needs actual IP spoofing) and router-level relay forwarding (already tracked by the TODO at `lib/router.js:15-18`).

## Tests

- New test `server bounds client-chosen relay connections` in `test/connections.js`: 40 handshakes carrying `relayThrough` against one server → exactly 32 outbound `dht.connect()` dials, counter tracks the bound.
- Full suite passes (`node test/all.js`, 94/94).
