### PR TITLE
Cap record value sizes and wire array lengths

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,11 +10,11 @@ const Router = require('./lib/router')
 const Cache = require('xache')
 const Server = require('./lib/server')
 const connect = require('./lib/connect')
-const { FIREWALL, BOOTSTRAP_NODES, COMMANDS } = require('./lib/constants')
+const { FIREWALL, BOOTSTRAP_NODES, COMMANDS, MAX_VALUE_SIZE } = require('./lib/constants')
 const { hash, createKeyPair } = require('./lib/crypto')
 const RawStreamSet = require('./lib/raw-stream-set')
 const ConnectionPool = require('./lib/connection-pool')
-const { STREAM_NOT_CONNECTED } = require('./lib/errors')
+const { STREAM_NOT_CONNECTED, VALUE_TOO_LARGE } = require('./lib/errors')
 
 const DEFAULTS = {
   ...DHT.DEFAULTS,
@@ -281,6 +281,8 @@ class HyperDHT extends DHT {
   }
 
   async immutablePut(value, opts = {}) {
+    if (value.byteLength > MAX_VALUE_SIZE) throw VALUE_TOO_LARGE()
+
     const target = b4a.allocUnsafe(32)
     sodium.crypto_generichash(target, value)
 
@@ -355,6 +357,8 @@ class HyperDHT extends DHT {
   }
 
   async mutablePut(keyPair, value, opts = {}) {
+    if (value.byteLength > MAX_VALUE_SIZE) throw VALUE_TOO_LARGE()
+
     const signMutable = opts.signMutable || Persistent.signMutable
 
     const target = b4a.allocUnsafe(32)

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -27,6 +27,12 @@ exports.FIREWALL = {
   RANDOM: 3
 }
 
+// Max byte size for immutable/mutable record values (BEP44 uses 1000)
+exports.MAX_VALUE_SIZE = 1024
+
+// Max entries in any array on the wire (addresses, relays, peers)
+exports.MAX_WIRE_ARRAY_LENGTH = 64
+
 exports.ERROR = {
   // noise / connection related
   NONE: 0,

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -107,4 +107,8 @@ module.exports = class DHTError extends Error {
   static SUSPENDED(msg = 'Suspended') {
     return new DHTError(msg, 'SUSPENDED', DHTError.SUSPENDED)
   }
+
+  static VALUE_TOO_LARGE(msg = 'Value is too large') {
+    return new DHTError(msg, 'VALUE_TOO_LARGE', DHTError.VALUE_TOO_LARGE)
+  }
 }

--- a/lib/messages.js
+++ b/lib/messages.js
@@ -1,5 +1,30 @@
 const c = require('compact-encoding')
 
+const { MAX_WIRE_ARRAY_LENGTH } = require('./constants')
+
+// Same wire format as c.array, but the length prefix is validated against
+// max before any allocation happens - c.array pre-sizes new Array(len)
+// straight from the untrusted length prefix
+function cappedArray(enc, max = MAX_WIRE_ARRAY_LENGTH) {
+  const arr = c.array(enc)
+
+  return {
+    preencode(state, m) {
+      arr.preencode(state, m)
+    },
+    encode(state, m) {
+      arr.encode(state, m)
+    },
+    decode(state) {
+      const len = c.uint.decode(state)
+      if (len > max) throw new Error('Array is too big')
+      const res = new Array(len)
+      for (let i = 0; i < len; i++) res[i] = enc.decode(state)
+      return res
+    }
+  }
+}
+
 const ipv4 = {
   ...c.ipv4Address,
   decode(state) {
@@ -11,7 +36,7 @@ const ipv4 = {
   }
 }
 
-const ipv4Array = c.array(ipv4)
+const ipv4Array = cappedArray(ipv4)
 
 const ipv6 = {
   ...c.ipv6Address,
@@ -24,7 +49,7 @@ const ipv6 = {
   }
 }
 
-const ipv6Array = c.array(ipv6)
+const ipv6Array = cappedArray(ipv6)
 
 exports.handshake = {
   preencode(state, m) {
@@ -69,7 +94,7 @@ const relayInfo = {
   }
 }
 
-const relayInfoArray = c.array(relayInfo)
+const relayInfoArray = cappedArray(relayInfo)
 
 const holepunchInfo = {
   preencode(state, m) {
@@ -311,9 +336,9 @@ const peer = (exports.peer = {
   }
 })
 
-const peers = (exports.peers = c.array(peer))
+const peers = (exports.peers = cappedArray(peer))
 
-const rawPeers = c.array(c.raw)
+const rawPeers = cappedArray(c.raw)
 
 exports.lookupRawReply = {
   preencode(state, m) {

--- a/lib/persistent.js
+++ b/lib/persistent.js
@@ -7,7 +7,7 @@ const unslab = require('unslab')
 
 const { encodeUnslab } = require('./encode')
 const m = require('./messages')
-const { NS, ERROR } = require('./constants')
+const { NS, ERROR, MAX_VALUE_SIZE } = require('./constants')
 
 const EMPTY = b4a.alloc(0)
 const TMP = b4a.allocUnsafe(32)
@@ -174,11 +174,14 @@ module.exports = class Persistent {
 
   onmutableput(req) {
     if (!req.target || !req.token || !req.value) return
+    if (req.value.byteLength > MAX_VALUE_SIZE + 128) return // cheap pre-decode bound
 
     const p = decode(m.mutablePutRequest, req.value)
     if (!p) return
 
     const { publicKey, seq, value, signature } = p
+
+    if (!value || value.byteLength > MAX_VALUE_SIZE) return
 
     const hash = b4a.allocUnsafe(32)
     sodium.crypto_generichash(hash, publicKey)
@@ -216,6 +219,7 @@ module.exports = class Persistent {
 
   onimmutableput(req) {
     if (!req.target || !req.token || !req.value) return
+    if (req.value.byteLength > MAX_VALUE_SIZE) return
 
     const hash = b4a.alloc(32)
     sodium.crypto_generichash(hash, req.value)

--- a/test/messages.js
+++ b/test/messages.js
@@ -1,6 +1,8 @@
 const test = require('brittle')
 const b4a = require('b4a')
+const c = require('compact-encoding')
 const m = require('../lib/messages')
+const { MAX_WIRE_ARRAY_LENGTH } = require('../lib/constants')
 
 test('basic noise payload', function (t) {
   const state = { start: 0, end: 0, buffer: null }
@@ -439,4 +441,55 @@ test('announce with refresh', function (t) {
   const d = m.announce.decode(state)
 
   t.alike(d, ann)
+})
+
+test('wire arrays allow entries up to the cap', function (t) {
+  const relayAddresses = []
+  for (let i = 0; i < MAX_WIRE_ARRAY_LENGTH; i++) {
+    relayAddresses.push({ host: '127.0.0.1', port: 1000 + i })
+  }
+
+  const peer = { publicKey: Buffer.alloc(32).fill('pk'), relayAddresses }
+  const state = { start: 0, end: 0, buffer: null }
+
+  m.peer.preencode(state, peer)
+  state.buffer = b4a.allocUnsafe(state.end)
+  m.peer.encode(state, peer)
+
+  state.start = 0
+  t.alike(m.peer.decode(state), peer, 'cap entries roundtrip')
+
+  relayAddresses.push({ host: '127.0.0.1', port: 9999 })
+
+  const over = { start: 0, end: 0, buffer: null }
+  m.peer.preencode(over, peer)
+  over.buffer = b4a.allocUnsafe(over.end)
+  m.peer.encode(over, peer)
+
+  over.start = 0
+  t.exception(() => m.peer.decode(over), /Array is too big/, 'cap + 1 entries on the wire throws')
+})
+
+test('crafted array length prefixes throw before allocating', function (t) {
+  // a peer record whose relayAddresses claims ~1M entries
+  const evilPeer = b4a.concat([b4a.alloc(32), c.encode(c.uint, 0x100000)])
+
+  t.exception(() => {
+    const state = { start: 0, end: evilPeer.byteLength, buffer: evilPeer }
+    m.peer.decode(state)
+  }, /Array is too big/)
+
+  // a noise payload with the addresses4 flag set and ~1M claimed entries
+  const evilPayload = b4a.concat([
+    c.encode(c.uint, 1), // version
+    c.encode(c.uint, 2), // flags = addresses4
+    c.encode(c.uint, 0), // error
+    c.encode(c.uint, 0), // firewall
+    c.encode(c.uint, 0x100000)
+  ])
+
+  t.exception(() => {
+    const state = { start: 0, end: evilPayload.byteLength, buffer: evilPayload }
+    m.noisePayload.decode(state)
+  }, /Array is too big/)
 })

--- a/test/storing.js
+++ b/test/storing.js
@@ -1,6 +1,12 @@
 const test = require('brittle')
+const b4a = require('b4a')
+const sodium = require('sodium-universal')
+const c = require('compact-encoding')
 const HyperDHT = require('../')
-const { swarm } = require('./helpers')
+const m = require('../lib/messages')
+const Persistent = require('../lib/persistent')
+const { MAX_VALUE_SIZE } = require('../lib/constants')
+const { swarm, createDHT } = require('./helpers')
 
 test('immutable put - get', async function (t) {
   const { nodes } = await swarm(t, 100)
@@ -61,4 +67,87 @@ test('mutable put - put - get', async function (t) {
   t.is(Buffer.isBuffer(res.value), true)
   t.is(Buffer.compare(res.signature, put2.signature), 0)
   t.is(res.value.toString(), 'testing two')
+})
+
+test('max-size values store and serve', async function (t) {
+  const { nodes } = await swarm(t)
+
+  const value = b4a.alloc(MAX_VALUE_SIZE, 7)
+  const { hash } = await nodes[0].immutablePut(value)
+  const res = await nodes[1].immutableGet(hash)
+  t.alike(res.value, value, 'max-size immutable value roundtrips')
+
+  const keyPair = HyperDHT.keyPair()
+  await nodes[0].mutablePut(keyPair, value)
+  const mres = await nodes[1].mutableGet(keyPair.publicKey)
+  t.alike(mres.value, value, 'max-size mutable value roundtrips')
+})
+
+test('immutable put rejects oversized values', async function (t) {
+  const a = createDHT({ bootstrap: [] })
+  t.teardown(() => a.destroy())
+
+  const big = b4a.alloc(MAX_VALUE_SIZE + 1, 1)
+  await t.exception(() => a.immutablePut(big), /VALUE_TOO_LARGE/, 'client-side reject')
+
+  const persistent = new Persistent(null, {
+    records: { maxSize: 100 },
+    bumps: { maxSize: 100 },
+    refreshes: { maxSize: 100 },
+    mutables: { maxSize: 100 },
+    immutables: { maxSize: 100 }
+  })
+  t.teardown(() => persistent.destroy())
+
+  const target = b4a.allocUnsafe(32)
+  sodium.crypto_generichash(target, big)
+  persistent.onimmutableput({ target, token: b4a.alloc(32), value: big })
+  t.absent(persistent.immutables.get(b4a.toString(target, 'hex')), 'storage node reject')
+
+  const ok = b4a.alloc(MAX_VALUE_SIZE, 2)
+  const okTarget = b4a.allocUnsafe(32)
+  sodium.crypto_generichash(okTarget, ok)
+  persistent.onimmutableput({ target: okTarget, token: b4a.alloc(32), value: ok, reply: () => {} })
+  t.alike(persistent.immutables.get(b4a.toString(okTarget, 'hex')), ok, 'max-size still stored')
+})
+
+test('mutable put rejects oversized values', async function (t) {
+  const a = createDHT({ bootstrap: [] })
+  t.teardown(() => a.destroy())
+  const keyPair = HyperDHT.keyPair()
+
+  const big = b4a.alloc(MAX_VALUE_SIZE + 1, 1)
+  await t.exception(() => a.mutablePut(keyPair, big), /VALUE_TOO_LARGE/, 'client-side reject')
+
+  const persistent = new Persistent(null, {
+    records: { maxSize: 100 },
+    bumps: { maxSize: 100 },
+    refreshes: { maxSize: 100 },
+    mutables: { maxSize: 100 },
+    immutables: { maxSize: 100 }
+  })
+  t.teardown(() => persistent.destroy())
+
+  const target = b4a.allocUnsafe(32)
+  sodium.crypto_generichash(target, keyPair.publicKey)
+  const k = b4a.toString(target, 'hex')
+
+  const signed = c.encode(m.mutablePutRequest, {
+    publicKey: keyPair.publicKey,
+    seq: 0,
+    value: big,
+    signature: b4a.alloc(64)
+  })
+  persistent.onmutableput({ target, token: b4a.alloc(32), value: signed })
+  t.absent(persistent.mutables.get(k), 'storage node reject')
+
+  const ok = b4a.alloc(MAX_VALUE_SIZE, 2)
+  const okSigned = c.encode(m.mutablePutRequest, {
+    publicKey: keyPair.publicKey,
+    seq: 0,
+    value: ok,
+    signature: Persistent.signMutable(0, ok, keyPair)
+  })
+  persistent.onmutableput({ target, token: b4a.alloc(32), value: okSigned, reply: () => {} })
+  t.ok(persistent.mutables.get(k), 'max-size still stored')
 })


### PR DESCRIPTION
Closes #297

## Problem

Two missing size limits on the record-storage / decoding path:

1. **No value-size cap on immutable/mutable PUTs.** `onimmutableput` / `onmutableput` stored whatever arrived (`lib/persistent.js:217-228`, `175-206`); the only limit was the transport's ~2KB datagram ceiling. With entry-count-based caches (32,768 × 2 generations each for immutables and mutables, `index.js:619-627`, 48h maxAge) a remote, unauthenticated peer could pin roughly ~250MB of heap per node and evict legitimate records via generation rotation. dht-rpc tokens don't prevent this — any reply from the target includes a free token bound to the requester's IP. Stored immutables are also served to anyone without a token, giving ~25× UDP reflection with spoofed-source GETs.

2. **`compact-encoding` array pre-allocation.** `c.array()` decodes the length prefix and immediately allocates `new Array(len)` (up to `0x100000` ≈ 1M entries, ~8MB, ms-scale CPU) *before* bounds-checking any content. A ~40-byte crafted datagram costs the victim ~8MB of GC churn before the decode throws (safely caught, but churn). Reachable pre-signature-verification via `ANNOUNCE` → `peer.relayAddresses`, via Noise handshake payload address arrays, and via query-reply decodes.

## Fix

- **`MAX_VALUE_SIZE = 1024`** (close to BEP44's 1000) exported from `lib/constants.js`:
  - `onimmutableput`: oversized `req.value` rejected before hashing/storing.
  - `onmutableput`: cheap pre-decode envelope bound, plus post-decode `value` size check **before** any signature verification work.
  - Client side (`immutablePut` / `mutablePut`): throws a new `VALUE_TOO_LARGE` error instead of emitting an unstorable value.
- **`cappedArray(enc, max)`** in `lib/messages.js`: identical wire format to `c.array`, but validates the length prefix against `max` *before* allocating or decoding elements. Applied to all wire arrays (`ipv4Array`, `ipv6Array`, `relayInfoArray`, `peers`, `rawPeers`) via a shared `MAX_WIRE_ARRAY_LENGTH = 64` — generous headroom over anything the protocol produces today (≤ 3 relays per announce, ≤ 20 records per lookup reply), so well-behaved peers see no change.

All limits live as named exports in `lib/constants.js` (`MAX_VALUE_SIZE`, `MAX_WIRE_ARRAY_LENGTH`) rather than inline literals.

## Compatibility note (needs maintainer sign-off)

The 1024-byte cap is a **behavior change**: values between ~1–1.9KB that store today will be rejected. I'm not aware of first-party consumers using values that large (Hyperswarm itself uses signed announce records, not these PUTs), but if you know of downstream users who do, the constant is a one-line change — or the cap could be set just under the datagram ceiling instead (which bounds memory at ~2× today's implicit limit but removes the amplification asymmetry much less). Happy to adjust.

## Tests

- `test/storing.js`: 1024-byte immutable + mutable values store and serve over a real testnet; 1025-byte values rejected client-side (`VALUE_TOO_LARGE`) and at the storage handler (pre-signature), with 1024-byte values still accepted at the handler.
- `test/messages.js`: 64-entry arrays roundtrip, 65 on the wire throws; crafted buffers claiming ~1M entries throw `Array is too big` immediately on decode of both `peer` and `noisePayload`.
- Full suite passes (`node test/all.js`, 98/98).
